### PR TITLE
Update to new lsst_sims and introduce variability

### DIFF
--- a/twinkles/generatePhosimInput.py
+++ b/twinkles/generatePhosimInput.py
@@ -10,14 +10,18 @@ from lsst.sims.catalogs.measures.instance import InstanceCatalog, CompoundInstan
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.catalogs.generation.db import CatalogDBObject
-from lsst.sims.catUtils.baseCatalogModels import OpSim3_61DBObject
+from lsst.sims.catalogs.generation.db.dbConnection import DBConnection
+from lsst.sims.catUtils.baseCatalogModels import OpSim3_61DBObject, StarObj, MsStarObj, \
+        BhbStarObj, WdStarObj, RRLyStarObj, CepheidStarObj, GalaxyBulgeObj, GalaxyDiskObj, \
+        GalaxyAgnObj
 from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import \
-        PhoSimCatalogPoint, PhoSimCatalogSersic2D, PhoSimCatalogZPoint
+        PhoSimCatalogPoint, PhoSimCatalogSersic2D
 from sprinkler import sprinklerCompound
+from twinklesCatalogDefs import TwinklesCatalogZPoint
 
 def generatePhosimInput():
 
-    opsimDB = os.path.join('.','enigma_1189_sqlite.db')
+    opsimDB = os.path.join('/Users/Bryce/Desktop/','enigma_1189_sqlite.db')
 
     #you need to provide ObservationMetaDataGenerator with the connection
     #string to an OpSim output database.  This is the connection string
@@ -38,53 +42,13 @@ def generatePhosimInput():
         obs_metadata.phoSimMetaData['SIM_VISTIME'] = (30, numpy.dtype(float))
         print 'Starting Visit: ', obs_metadata.phoSimMetaData['Opsim_obshistid'][0]
 
-        compoundICList = []
+        compoundDBList = [MsStarObj, BhbStarObj, WdStarObj, RRLyStarObj, CepheidStarObj, GalaxyBulgeObj,
+                          GalaxyDiskObj, GalaxyAgnObj]
+        compoundICList = [PhoSimCatalogPoint, PhoSimCatalogPoint, PhoSimCatalogPoint, PhoSimCatalogPoint,
+                          PhoSimCatalogPoint, PhoSimCatalogSersic2D, PhoSimCatalogSersic2D, TwinklesCatalogZPoint]
 
-        #Add Instance Catalogs for phoSim stars
-        for starName in starObjNames:
-            while True:
-                try:
-                    starDBObj = CatalogDBObject.from_objid(starName)
-                    compoundICList.append(PhoSimCatalogPoint(starDBObj, obs_metadata=obs_metadata))
-                    break
-                except RuntimeError:
-                    continue
-            print starName
-
-        #Add phosim Galaxy Instance Catalogs to compound Instance Catalog
-        while True:
-            try:
-                galsBulge = CatalogDBObject.from_objid('galaxyBulge')
-                compoundICList.append(PhoSimCatalogSersic2D(galsBulge, obs_metadata=obs_metadata))
-                break
-            except RuntimeError:
-                continue
-        print 'bulge'
-
-        while True:
-            try:
-                galsDisk = CatalogDBObject.from_objid('galaxyDisk')
-                compoundICList.append(PhoSimCatalogSersic2D(galsDisk, obs_metadata=obs_metadata))
-                break
-            except RuntimeError:
-                continue
-        print 'disk'
-
-        while True:
-            try:
-                galsAGN = CatalogDBObject.from_objid('galaxyAgn')
-                compoundICList.append(PhoSimCatalogZPoint(galsAGN, obs_metadata=obs_metadata))
-                break
-            except RuntimeError:
-                continue
-        print 'agn'
-
-        while True:
-            try:
-                totalCat = CompoundInstanceCatalog(compoundICList, obs_metadata=obs_metadata, compoundDBclass=sprinklerCompound)
-                break
-            except RuntimeError:
-                continue
+        totalCat = CompoundInstanceCatalog(compoundICList, compoundDBList, obs_metadata=obs_metadata,
+                                                   compoundDBclass=sprinklerCompound)
 
         totalCat.write_catalog(filename)
         print "Finished Writing Visit: ", obs_metadata.phoSimMetaData['Opsim_obshistid'][0]

--- a/twinkles/sprinkler.py
+++ b/twinkles/sprinkler.py
@@ -6,6 +6,7 @@ Created on Feb 6, 2015
 import om10
 import numpy as np
 from lsst.sims.catUtils.baseCatalogModels import GalaxyTileCompoundObj
+from lsst.sims.utils import radiansFromArcsec
 import random
 import os
 
@@ -15,6 +16,12 @@ class sprinklerCompound(GalaxyTileCompoundObj):
     objectTypeID = 1024
 
     def _final_pass(self, results):
+        #From the original GalaxyTileCompoundObj final pass method
+        for name in results.dtype.fields:
+            if 'raJ2000' in name or 'decJ2000' in name:
+                results[name] = np.radians(results[name])
+
+        #Use Sprinkler now
         sp = sprinkler(results)
         results = sp.sprinkle()
         return results
@@ -91,10 +98,9 @@ class sprinkler():
                     row['galaxyDisk_redshift'] = newlens['ZLENS']
                     row['galaxyAgn_redshift'] = newlens['ZLENS']
                     row['galaxyBulge_magNorm'] = newlens['APMAG_I'] #Need to convert this to correct band
-                    arcsec2rad = 4.84813681109536e-06 #To convert from arcsec to radians for catalog
                     newlens['REFF'] = 1.0 #Hard coded for now. See issue in OM10 github.
-                    row['galaxyBulge_majorAxis'] = newlens['REFF'] * arcsec2rad
-                    row['galaxyBulge_minorAxis'] = newlens['REFF'] * (1 - newlens['ELLIP']) * arcsec2rad
+                    row['galaxyBulge_majorAxis'] = radiansFromArcsec(newlens['REFF'])
+                    row['galaxyBulge_minorAxis'] = radiansFromArcsec(newlens['REFF'] * (1 - newlens['ELLIP']))
                     #Convert orientation angle to west of north from east of north by *-1.0 and convert to radians
                     row['galaxyBulge_positionAngle'] = newlens['PHIE']*(-1.0)*np.pi/180.0
                     #Replace original entry with new entry

--- a/twinkles/twinklesCatalogDefs.py
+++ b/twinkles/twinklesCatalogDefs.py
@@ -1,0 +1,50 @@
+"""Instance Catalog"""
+import numpy
+from lsst.sims.utils import SpecMap, defaultSpecMap
+from lsst.sims.catalogs.measures.instance import InstanceCatalog
+from lsst.sims.utils import arcsecFromRadians
+from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import PhosimInputBase
+from lsst.sims.catUtils.mixins import AstrometryStars, AstrometryGalaxies, \
+                                      EBVmixin, VariabilityStars
+
+class TwinklesCatalogZPoint(PhosimInputBase, AstrometryGalaxies, EBVmixin, VariabilityStars):
+#class TwinklesCatalogZPoint(PhosimInputBase, AstrometryGalaxies, EBVmixin):
+
+    catalog_type = 'twinkles_catalog_ZPOINT'
+    column_outputs = ['prefix', 'uniqueId','raPhoSim','decPhoSim','phoSimMagNorm','sedFilepath',
+                      'redshift','shear1','shear2','kappa','raOffset','decOffset',
+                      'spatialmodel','galacticExtinctionModel','galacticAv','galacticRv',
+                      'internalExtinctionModel']#, 'delta_lsst_r']
+    default_columns = [('shear1', 0., float), ('shear2', 0., float), ('kappa', 0., float),
+                       ('raOffset', 0., float), ('decOffset', 0., float), ('spatialmodel', 'ZPOINT', (str, 6)),
+                       ('galacticExtinctionModel', 'CCM', (str,3)),
+                       ('galacticAv', 0.1, float),
+                       ('internalExtinctionModel', 'none', (str,4))]
+    default_formats = {'S':'%s', 'f':'%.9g', 'i':'%i'}
+    delimiter = " "
+    spatialModel = "point"
+    transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees}
+
+    def get_phoSimMagNorm(self):
+            """
+            This getter returns the magnitude normalization expected by PhoSim (the magnitude at
+            500 nm).
+            To account for variability, the getter adds the delta_lsst_x column from the Variability
+            mixin where 'x' is the bandpass defined by self.observation_metadata.bandpass (assuming
+            that self.observation_metadata.bandpass is not list-like; if it is list-like, then no
+            variability is added to the magNorm value).
+            Redshift is currently ignored.  That may or may  not be appropriate.  This requires
+            further investigation into the behavior of PhoSim.
+            """
+
+            magNorm = self.column_by_name('magNorm')
+            varName = None
+            if self.obs_metadata is not None:
+                if self.obs_metadata.bandpass is not None:
+                    if not hasattr(self.obs_metadata.bandpass, '__iter__'):
+                        varName = 'delta_lsst_' + self.obs_metadata.bandpass
+
+            if varName is not None and varName in self._all_available_columns:
+                magNorm_out = magNorm + self.column_by_name(varName)
+
+            return magNorm_out


### PR DESCRIPTION
As indicated by #79 there was an update to database connections in catsim. This especially affected the compoundInstanceCatalogs that twinkles uses. This pull request fixes that. It also contains a start on issue #47 by including variability in AGNs but the time delay still needs to be accounted for in the lenses.