### PR TITLE
Added Time Delays from OM10 into sprinkled objects

### DIFF
--- a/twinkles/generatePhosimInput.py
+++ b/twinkles/generatePhosimInput.py
@@ -27,7 +27,7 @@ def generatePhosimInput():
     #string to an OpSim output database.  This is the connection string
     #to a test database that comes when you install CatSim.
     generator = ObservationMetaDataGenerator(database=opsimDB, driver='sqlite')
-    obsMetaDataResults = generator.getObservationMetaData(fieldRA=(53, 54), fieldDec=(-29, -27), boundLength=0.3)
+    obsMetaDataResults = generator.getObservationMetaData(fieldRA=(53, 54), fieldDec=(-29, -27), boundLength=0.01)
 
     rVisits = []
     for md in obsMetaDataResults:

--- a/twinkles/generatePhosimInput.py
+++ b/twinkles/generatePhosimInput.py
@@ -27,7 +27,7 @@ def generatePhosimInput():
     #string to an OpSim output database.  This is the connection string
     #to a test database that comes when you install CatSim.
     generator = ObservationMetaDataGenerator(database=opsimDB, driver='sqlite')
-    obsMetaDataResults = generator.getObservationMetaData(fieldRA=(53, 54), fieldDec=(-29, -27), boundLength=0.01)
+    obsMetaDataResults = generator.getObservationMetaData(fieldRA=(53, 54), fieldDec=(-29, -27), boundLength=0.3)
 
     rVisits = []
     for md in obsMetaDataResults:

--- a/twinkles/sprinkler.py
+++ b/twinkles/sprinkler.py
@@ -21,13 +21,18 @@ class sprinklerCompound(GalaxyTileCompoundObj):
             if 'raJ2000' in name or 'decJ2000' in name:
                 results[name] = np.radians(results[name])
 
+        new_results = np.zeros(results.shape, dtype = results.dtype.descr + [('t0Delay', float)])
+        for name in results.dtype.names:
+            new_results[name] = results[name]
+
         #Use Sprinkler now
-        sp = sprinkler(results)
-        results = sp.sprinkle()
-        return results
+        sp = sprinkler(new_results)
+        new_results = sp.sprinkle()
+
+        return new_results
 
 class sprinkler():
-    def __init__(self, catsim_cat, density_param = 0.1):
+    def __init__(self, catsim_cat, density_param = 1.):
         """
         Input:
         catsim_cat:
@@ -80,6 +85,7 @@ class sprinkler():
                             lensrow[str(lensPart + '_decJ2000')] += (newlens['YIMG'][i] - newlens['YSRC']) / 3600.0 / 180.0 * np.pi
                         ###Should this 'mag' be added to all parts? How should we update the ids for the lensed objects?
                         lensrow['galaxyAgn_magNorm'] += newlens['MAG'][i]
+                        lensrow['t0Delay'] = newlens['DELAY'][i]
                         updated_catalog = np.append(updated_catalog, lensrow)
 
                     #Now manipulate original entry to be the lens galaxy with desired properties

--- a/twinkles/sprinkler.py
+++ b/twinkles/sprinkler.py
@@ -80,7 +80,7 @@ class sprinkler():
                             lensrow[str(lensPart + '_raJ2000')] += (newlens['XIMG'][i] - newlens['XSRC']) / 3600.0 / 180.0 * np.pi
                             lensrow[str(lensPart + '_decJ2000')] += (newlens['YIMG'][i] - newlens['YSRC']) / 3600.0 / 180.0 * np.pi
                         ###Should this 'mag' be added to all parts? How should we update the ids for the lensed objects?
-                        lensrow['galaxyAgn_magNorm'] += newlens['MAG'][i]
+                        lensrow['galaxyAgn_magNorm'] -= newlens['MAG'][i]
                         varString = json.loads(lensrow['galaxyAgn_varParamStr'])
                         varString['pars']['t0Delay'] = newlens['DELAY'][i]
                         varString['varMethodName'] = 'applyAgnTimeDelay'

--- a/twinkles/sprinkler.py
+++ b/twinkles/sprinkler.py
@@ -7,7 +7,6 @@ import om10
 import numpy as np
 from lsst.sims.catUtils.baseCatalogModels import GalaxyTileCompoundObj
 from lsst.sims.utils import radiansFromArcsec
-#import random
 import json
 import os
 

--- a/twinkles/sprinkler.py
+++ b/twinkles/sprinkler.py
@@ -7,7 +7,8 @@ import om10
 import numpy as np
 from lsst.sims.catUtils.baseCatalogModels import GalaxyTileCompoundObj
 from lsst.sims.utils import radiansFromArcsec
-import random
+#import random
+import json
 import os
 
 
@@ -21,15 +22,11 @@ class sprinklerCompound(GalaxyTileCompoundObj):
             if 'raJ2000' in name or 'decJ2000' in name:
                 results[name] = np.radians(results[name])
 
-        new_results = np.zeros(results.shape, dtype = results.dtype.descr + [('t0Delay', float)])
-        for name in results.dtype.names:
-            new_results[name] = results[name]
-
         #Use Sprinkler now
-        sp = sprinkler(new_results)
-        new_results = sp.sprinkle()
+        sp = sprinkler(results)
+        results = sp.sprinkle()
 
-        return new_results
+        return results
 
 class sprinkler():
     def __init__(self, catsim_cat, density_param = 1.):
@@ -85,7 +82,11 @@ class sprinkler():
                             lensrow[str(lensPart + '_decJ2000')] += (newlens['YIMG'][i] - newlens['YSRC']) / 3600.0 / 180.0 * np.pi
                         ###Should this 'mag' be added to all parts? How should we update the ids for the lensed objects?
                         lensrow['galaxyAgn_magNorm'] += newlens['MAG'][i]
-                        lensrow['t0Delay'] = newlens['DELAY'][i]
+                        varString = json.loads(lensrow['galaxyAgn_varParamStr'])
+                        varString['pars']['t0Delay'] = newlens['DELAY'][i]
+                        varString['varMethodName'] = 'applyAgnTimeDelay'
+                        lensrow['galaxyAgn_varParamStr'] = json.dumps(varString)
+
                         updated_catalog = np.append(updated_catalog, lensrow)
 
                     #Now manipulate original entry to be the lens galaxy with desired properties

--- a/twinkles/sprinkler.py
+++ b/twinkles/sprinkler.py
@@ -28,7 +28,7 @@ class sprinklerCompound(GalaxyTileCompoundObj):
         return results
 
 class sprinkler():
-    def __init__(self, catsim_cat, density_param = 1.):
+    def __init__(self, catsim_cat, om10_cat=str(os.environ['OM10_DIR']+"/data/qso_mock.fits"), density_param = 1.):
         """
         Input:
         catsim_cat:
@@ -45,7 +45,7 @@ class sprinkler():
 
         self.catalog = catsim_cat
         # ****** THIS ASSUMES THAT THE ENVIRONMENT VARIABLE OM10_DIR IS SET *******
-        lensdb = om10.DB(catalog=os.environ['OM10_DIR']+"/data/qso_mock.fits")
+        lensdb = om10.DB(catalog=om10_cat)
         self.lenscat = lensdb.lenses.copy()
         self.density_param = density_param
         #return

--- a/twinkles/twinklesCatalogDefs.py
+++ b/twinkles/twinklesCatalogDefs.py
@@ -48,37 +48,3 @@ class TwinklesCatalogZPoint(PhosimInputBase, AstrometryGalaxies, EBVmixin, Varia
                 magNorm_out = magNorm + self.column_by_name(varName)
 
             return magNorm_out
-
-    def _query_and_write(self, filename, chunk_size=None, write_header=True,
-                         write_mode='w', obs_metadata=None, constraint=None):
-        """
-        This method queries db_obj, and then writes the resulting recarray
-        to the specified ASCII output file.
-        @param [in] filename is the name of the ASCII file to be written
-        @param [in] obs_metadata is an ObservationMetaData instantiation
-        characterizing the telescope pointing (optional)
-        @param [in] constraint is an optional SQL constraint applied to the database query.
-        @param [in] chunk_size is an optional parameter telling the CompoundInstanceCatalog
-        to query the database in manageable chunks (in case returning the whole catalog
-        takes too much memory)
-        @param [in] write_header a boolean specifying whether or not to add a header
-        to the output catalog (default True)
-        @param [in] write_mode is 'w' if you want to overwrite the output file or
-        'a' if you want to append to an existing output file (default: 'w')
-        """
-
-
-        file_handle = open(filename, write_mode)
-        if write_header:
-            self.write_header(file_handle)
-
-        query_result = self.db_obj.query_columns(colnames=self._active_columns,
-                                                 obs_metadata=obs_metadata,
-                                                 constraint=constraint,
-                                                 chunk_size=chunk_size)
-
-        for chunk in query_result:
-            print chunk.dtype.fields
-            self._write_recarray(chunk, file_handle)
-
-        file_handle.close()

--- a/twinkles/twinklesCatalogDefs.py
+++ b/twinkles/twinklesCatalogDefs.py
@@ -6,15 +6,15 @@ from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import PhosimInputBase
 from lsst.sims.catUtils.mixins import AstrometryStars, AstrometryGalaxies, \
                                       EBVmixin, VariabilityStars
+from twinklesVariabilityMixins import VariabilityTwinkles
 
-class TwinklesCatalogZPoint(PhosimInputBase, AstrometryGalaxies, EBVmixin, VariabilityStars):
-#class TwinklesCatalogZPoint(PhosimInputBase, AstrometryGalaxies, EBVmixin):
+class TwinklesCatalogZPoint(PhosimInputBase, AstrometryGalaxies, EBVmixin, VariabilityTwinkles):
 
     catalog_type = 'twinkles_catalog_ZPOINT'
     column_outputs = ['prefix', 'uniqueId','raPhoSim','decPhoSim','phoSimMagNorm','sedFilepath',
                       'redshift','shear1','shear2','kappa','raOffset','decOffset',
                       'spatialmodel','galacticExtinctionModel','galacticAv','galacticRv',
-                      'internalExtinctionModel']#, 'delta_lsst_r']
+                      'internalExtinctionModel']
     default_columns = [('shear1', 0., float), ('shear2', 0., float), ('kappa', 0., float),
                        ('raOffset', 0., float), ('decOffset', 0., float), ('spatialmodel', 'ZPOINT', (str, 6)),
                        ('galacticExtinctionModel', 'CCM', (str,3)),
@@ -48,3 +48,37 @@ class TwinklesCatalogZPoint(PhosimInputBase, AstrometryGalaxies, EBVmixin, Varia
                 magNorm_out = magNorm + self.column_by_name(varName)
 
             return magNorm_out
+
+    def _query_and_write(self, filename, chunk_size=None, write_header=True,
+                         write_mode='w', obs_metadata=None, constraint=None):
+        """
+        This method queries db_obj, and then writes the resulting recarray
+        to the specified ASCII output file.
+        @param [in] filename is the name of the ASCII file to be written
+        @param [in] obs_metadata is an ObservationMetaData instantiation
+        characterizing the telescope pointing (optional)
+        @param [in] constraint is an optional SQL constraint applied to the database query.
+        @param [in] chunk_size is an optional parameter telling the CompoundInstanceCatalog
+        to query the database in manageable chunks (in case returning the whole catalog
+        takes too much memory)
+        @param [in] write_header a boolean specifying whether or not to add a header
+        to the output catalog (default True)
+        @param [in] write_mode is 'w' if you want to overwrite the output file or
+        'a' if you want to append to an existing output file (default: 'w')
+        """
+
+
+        file_handle = open(filename, write_mode)
+        if write_header:
+            self.write_header(file_handle)
+
+        query_result = self.db_obj.query_columns(colnames=self._active_columns,
+                                                 obs_metadata=obs_metadata,
+                                                 constraint=constraint,
+                                                 chunk_size=chunk_size)
+
+        for chunk in query_result:
+            print chunk.dtype.fields
+            self._write_recarray(chunk, file_handle)
+
+        file_handle.close()

--- a/twinkles/twinklesVariabilityMixins.py
+++ b/twinkles/twinklesVariabilityMixins.py
@@ -12,7 +12,6 @@ class TimeDelayVariability(Variability):
         dMags = {}
         expmjd = numpy.asarray(expmjd_in,dtype=float)
         toff = numpy.float(params['t0_mjd']+params['t0Delay'])
-        print toff
         seed = int(params['seed'])
         sfint = {}
         sfint['u'] = params['agn_sfu']

--- a/twinkles/twinklesVariabilityMixins.py
+++ b/twinkles/twinklesVariabilityMixins.py
@@ -1,0 +1,102 @@
+import numpy
+import math
+from scipy.interpolate import interp1d
+from lsst.sims.catalogs.measures.instance import register_class, register_method, compound
+from lsst.sims.catUtils.mixins import Variability
+
+@register_class
+class TimeDelayVariability(Variability):
+
+    @register_method('applyAgnTimeDelay')
+    def applyAgnTimeDelay(self, params, expmjd_in):
+        dMags = {}
+        expmjd = numpy.asarray(expmjd_in,dtype=float)
+        toff = numpy.float(params['t0_mjd']+params['t0Delay'])
+        print toff
+        seed = int(params['seed'])
+        sfint = {}
+        sfint['u'] = params['agn_sfu']
+        sfint['g'] = params['agn_sfg']
+        sfint['r'] = params['agn_sfr']
+        sfint['i'] = params['agn_sfi']
+        sfint['z'] = params['agn_sfz']
+        sfint['y'] = params['agn_sfy']
+        tau = params['agn_tau']
+        epochs = expmjd - toff
+        if epochs.min() < 0:
+            raise RuntimeError("WARNING: Time offset greater than minimum epoch.  " +
+                               "Not applying variability. "+
+                               "expmjd: %e should be > toff: %e  " % (expmjd, toff) +
+                               "in applyAgn variability method")
+
+        endepoch = epochs.max()
+
+        dt = tau/100.
+        nbins = int(math.ceil(endepoch/dt))
+        dt = (endepoch/nbins)/tau
+        sdt = math.sqrt(dt)
+        numpy.random.seed(seed=seed)
+        es = numpy.random.normal(0., 1., nbins)
+        for k in sfint.keys():
+            dx = numpy.zeros(nbins+1)
+            dx[0] = 0.
+            for i in range(nbins):
+                #The second term differs from Zeljko's equation by sqrt(2.)
+                #because he assumes stdev = sfint/sqrt(2)
+                dx[i+1] = -dx[i]*dt + sfint[k]*es[i]*sdt + dx[i]
+            x = numpy.linspace(0, endepoch, nbins+1)
+            intdx = interp1d(x, dx)
+            magoff = intdx(epochs)
+            dMags[k] = magoff
+        return dMags
+
+class VariabilityTwinkles(TimeDelayVariability):
+    """
+    This is a mixin which wraps the methods from the class Variability
+    into getters for InstanceCatalogs (specifically, InstanceCatalogs
+    of stars).  Getters in this method should define columns named like
+    delta_columnName
+    where columnName is the name of the baseline (non-varying) magnitude
+    column to which delta_columnName will be added.  The getters in the
+    photometry mixins will know to find these columns and add them to
+    columnName, provided that the columns here follow this naming convention.
+    Thus: merely including VariabilityStars in the inheritance tree of
+    an InstanceCatalog daughter class will activate variability for any column
+    for which delta_columnName is defined.
+    """
+
+    @compound('delta_lsst_u', 'delta_lsst_g', 'delta_lsst_r',
+             'delta_lsst_i', 'delta_lsst_z', 'delta_lsst_y')
+    def get_stellar_variability(self):
+        """
+        Getter for the change in magnitudes due to stellar
+        variability.  The PhotometryStars mixin is clever enough
+        to automatically add this to the baseline magnitude.
+        """
+
+        varParams = self.column_by_name('varParamStr')
+
+        output = numpy.empty((6,len(varParams)))
+
+        for ii, vv in enumerate(varParams):
+            if vv != numpy.unicode_("None") and \
+               self.obs_metadata is not None and \
+               self.obs_metadata.mjd is not None:
+
+                deltaMag = self.applyVariability(vv)
+
+                output[0][ii] = deltaMag['u']
+                output[1][ii] = deltaMag['g']
+                output[2][ii] = deltaMag['r']
+                output[3][ii] = deltaMag['i']
+                output[4][ii] = deltaMag['z']
+                output[5][ii] = deltaMag['y']
+            else:
+                output[0][ii] = 0.0
+                output[1][ii] = 0.0
+                output[2][ii] = 0.0
+                output[3][ii] = 0.0
+                output[4][ii] = 0.0
+                output[5][ii] = 0.0
+
+        return output

--- a/twinkles/twinklesVariabilityMixins.py
+++ b/twinkles/twinklesVariabilityMixins.py
@@ -53,23 +53,23 @@ class VariabilityTwinkles(TimeDelayVariability):
     """
     This is a mixin which wraps the methods from the class Variability
     into getters for InstanceCatalogs (specifically, InstanceCatalogs
-    of stars).  Getters in this method should define columns named like
+    with AGNs).  Getters in this method should define columns named like
     delta_columnName
     where columnName is the name of the baseline (non-varying) magnitude
     column to which delta_columnName will be added.  The getters in the
     photometry mixins will know to find these columns and add them to
     columnName, provided that the columns here follow this naming convention.
-    Thus: merely including VariabilityStars in the inheritance tree of
+    Thus: merely including VariabilityTwinkles in the inheritance tree of
     an InstanceCatalog daughter class will activate variability for any column
     for which delta_columnName is defined.
     """
 
     @compound('delta_lsst_u', 'delta_lsst_g', 'delta_lsst_r',
              'delta_lsst_i', 'delta_lsst_z', 'delta_lsst_y')
-    def get_stellar_variability(self):
+    def get_agn_variability(self):
         """
-        Getter for the change in magnitudes due to stellar
-        variability.  The PhotometryStars mixin is clever enough
+        Getter for the change in magnitudes due to agn
+        variability.  The PhotometryTwinkles mixin is clever enough
         to automatically add this to the baseline magnitude.
         """
 


### PR DESCRIPTION
By adjusting the variability parameters string from catsim database we can now add in time delays to the variability of our lensed AGN. This takes care of #47 