### PR TITLE
Setup modifications

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ this is becomes your default version of python.
 
 First you need to add the LSST "channel:"
 ```
-conda config --add channels http://research.majuric.org/conda/stable
+conda config -add channels http://eupsforge.net/conda/dev
 ```
 Now do:
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,6 +49,7 @@ This needs to be done every time you start a new shell - so these lines could be
 ## 4. Install python packages
 
 We use several useful python packages that don't come with the DM stack:
+(however make sure that the pip is the version installed by conda)
 ```
 pip install astropy
 pip install pandas

--- a/setup/declare.sh
+++ b/setup/declare.sh
@@ -1,0 +1,2 @@
+# Run this the first time only
+eups declare -r . Twinkles $USER  --tag=$USER

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,9 +1,2 @@
-inst_dir=$( cd $(dirname $BASH_SOURCE)/../..; pwd -P )
-if [ ! -d "$inst_dir/ups_db" ]; then
-   mkdir $inst_dir/ups_db
-fi
-export EUPS_PATH=$inst_dir:${LSSTSW}/stack
-. ${LSSTSW}/bin/setup.sh
-setup lsst_sims
-eups declare Twinkles -r . -c
-setup Twinkles
+# Setup lsst_sims in the way you usually do
+setup Twinkles -t $USER

--- a/ups/Twinkles.table
+++ b/ups/Twinkles.table
@@ -1,4 +1,5 @@
 setupRequired(lsst_sims)
+setupRequired(sncosmo)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
 


### PR DESCRIPTION
@danielsf @jchiang87 

Here is a setup that seems to work for me (and I thought could work for everyone). I split the setup into a declare.sh and a setup.sh (talking to Scott), where the declare is meant to be run only once by the user. The setup is meant to be run everytime a new shell is opened, *after* setting up lsst-sims in whatever way the user usually does. I did this to avoid the problem of having to specify what tags the user would have on lsst_sims.