### PR TITLE
Issue/160/installation - Heather instructing, Phil testing

### DIFF
--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -38,18 +38,23 @@ Pipelines <https://pipelines.lsst.io/install/conda.html>`_. The first thing that
    conda update conda
 
 The following commands will download and activate the current release versions of the LSST Science Pipelines in a 
-new Conda environment named "lsst":
+new Conda environment named "lsst". At various times they need to to type `y`, so unfortunately you cannot leave them too long. They 
+each take a few minutes, except for the `conda install`, which takes a bit longer.  
 
 .. code-block:: bash
 
    conda config --add channels http://conda.lsst.codes/stack  
    conda create --name lsst python=2
+   
+You are now ready to install the `lsst` software. If you are a C-shell user, the `source activate` command below
+will not work, as that script only supports `bash` and `zsh`. A workaround is to switch to a `bash` shell at this point, 
+and then stay in that bash shell to do the other two commands below.
+
    source ${HOME}/miniconda2/bin/activate lsst
    conda install lsst-distrib lsst-sims
    source eups-setups.sh
 
-
-You are now set up to use the DM Stack in the current shell.
+You should now be set up to use the DM Stack in the current `bash` shell.
 
 Set Up Environment to Use LSST Code
 -----------------------------------

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -85,13 +85,21 @@ Install Optional Python Modules Not Included with DMStack
     
 Install PhoSim
 -----------------------
-The PhoSim Confluence page is available `here <https://confluence.lsstcorp.org/display/PHOSIM>`_.
+The PhoSim Confluence page is available `here <https://confluence.lsstcorp.org/display/PHOSIM>`_. The code is available 
+from LSST via `git`, and needs the `cfitsio` and `fftw3` libraries: you'll be asked to point to their locations by the `PhoSim` 
+configure script, or if you can't, it will offer to install them for you from source.
      
 .. code-block:: bash
 
     mkdir ~/repos
     cd ~/repos
     git clone https://stash.lsstcorp.org/scm/sim/sims_phosim.git
+
+This takes a few minutes, as the `sims_phosim` repo is large. Once it has been downloaded,
+ 
+.. code-block:: bash
+
+    cd sims_phosim
     setup cfitsio
     setup fftw
     ./configure

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -39,7 +39,7 @@ Pipelines <https://pipelines.lsst.io/install/conda.html>`_. The first thing that
 
 The following commands will download and activate the current release versions of the LSST Science Pipelines in a 
 new Conda environment named "lsst". At various times they need to to type "`y`", so unfortunately you cannot leave them too long. They 
-each take a few minutes, except for the `conda install`, which takes a bit longer.  
+each take a few minutes, except for the `conda install`, which takes about an hour.  
 
 .. code-block:: bash
 
@@ -80,7 +80,7 @@ Install Optional Python Modules Not Included with DMStack
 .. code-block:: bash
 
     conda install nose
-    conda install coverge
+    conda install coverage
     conda install iminuit
     
 Install PhoSim

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -51,8 +51,11 @@ new Conda environment named "lsst":
 
 You are now set up to use the DM Stack in the current shell.
 
-Environment Set up to Use LSST Code
--------------------------------------
+Set Up Environment to Use LSST Code
+-----------------------------------
+Every time you start a new shell, you need to set up its environment to enable use of the LSST code. The following lines could be 
+worth adding to your `.bashrc` file or equivalent.
+C-shell users would use `eups_setup.csh` and `setenv` in their `.login` file.
 
 .. code-block:: bash
 
@@ -63,10 +66,6 @@ Environment Set up to Use LSST Code
    setup obs_lsstSim
    setup lsst_sims
 
-This needs to be done every time you start a new shell - so these lines 
-could be worth adding to your `.bashrc` file or equivalent. Note that 
-c-shell users can use `eups_setup.csh` and use `setenv` in their `.login` 
-file.
 
 Install Optional Python Modules Not Included with DMStack
 ----------------------------
@@ -129,6 +128,7 @@ This is where the objects that will populate the catalog are stored.
 
 Supernova Sprinkling Setup
 ---------------------------
+Coming soon!
 
 
 Important Installation Notes

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -8,8 +8,8 @@ This page contains our notes on how to set your Mac laptop up to run the LSST DM
    :depth: 4
 
 
-DM Stack and Sims Installation
-================================
+Installing the DM Stack and Sims Tools
+======================================
 The Twinkles package uses the LSST DM Stack's `afw` code, and also the LSST
 Sims tools (among other things). Here's how to get everything working.
 
@@ -104,8 +104,8 @@ Important DM Stack Installation Notes
     conda install astropy=1.1.2
 
     
-PhoSim Installation
-================================
+Installing PhoSim for Twinkles
+==============================
 `PhoSim` is not distributed with the rest of the LSST sims tools, but is readily available as an independent package. 
 The PhoSim confluence page is available `here <https://confluence.lsstcorp.org/display/PHOSIM>`_. The code is obtained 
 from LSST via `git`, and needs the `cfitsio` and `fftw3` libraries: you'll be asked to point to their locations by the `PhoSim` 
@@ -131,6 +131,10 @@ You'll have to point to the correct cfitsio and fftw3 libraries and headers for 
 
 Test `PhoSim`
 ---------------
+For Twinkles, we need to be able to query the `CatSim` database to make the "instance catalogs" that `PhoSim` needs - so our test 
+exercises this. The code below will only work if you have authorized access to the `CatSim` database at the University of 
+Washington - see the [instructions here](https://confluence.lsstcorp.org/display/SIM/Accessing+the+UW+CATSIM+Database) for how to 
+get that access.
 
 .. code-block:: bash
 
@@ -139,8 +143,8 @@ Test `PhoSim`
     python $SIMS_CATUTILS_DIR/examples/generatePhosimInput.py
     ./phosim ~/TwinklesData/phoSim_example.txt --sensor="R22_S11" -c examples/nobackground
 
-This produces a file `PhoSim` can run.
-Images show up in the "output" directory.
+`generatePhosimInput.py` produces a file `PhoSim` can run; 
+the output images made by `PhoSim` show up in the "output" directory.
 
 
 Twinkles-specific Installation Notes

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -1,6 +1,8 @@
-################################
-Getting Started on your Laptop
-################################
+##################################
+Getting Started on an Apple Laptop
+##################################
+
+This page contains our notes on how to set your Mac laptop up to run the LSST DM stack and sims tools. 
 
 .. contents::
    :depth: 4

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -38,7 +38,7 @@ Pipelines <https://pipelines.lsst.io/install/conda.html>`_. The first thing that
    conda update conda
 
 The following commands will download and activate the current release versions of the LSST Science Pipelines in a 
-new Conda environment named "lsst". At various times they need to to type `y`, so unfortunately you cannot leave them too long. They 
+new Conda environment named "lsst". At various times they need to to type "`y`", so unfortunately you cannot leave them too long. They 
 each take a few minutes, except for the `conda install`, which takes a bit longer.  
 
 .. code-block:: bash
@@ -49,6 +49,8 @@ each take a few minutes, except for the `conda install`, which takes a bit longe
 You are now ready to install the `lsst` software. If you are a C-shell user, the `source activate` command below
 will not work, as that script only supports `bash` and `zsh`. A workaround is to switch to a `bash` shell at this point, 
 and then stay in that bash shell to do the other two commands below.
+
+.. code-block:: bash
 
    source ${HOME}/miniconda2/bin/activate lsst
    conda install lsst-distrib lsst-sims

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -45,13 +45,16 @@ each take a few minutes, except for the `conda install`, which takes about an ho
    conda config --add channels http://conda.lsst.codes/stack  
    conda create --name lsst python=2
    
-You are now ready to install the `lsst` software. If you are a C-shell user, the `source activate` command below
-will not work, as that script only supports `bash` and `zsh`. A workaround is to switch to a `bash` shell at this point, 
-and then stay in that bash shell to do the other two commands below.
+You are now ready to install the `lsst` software. 
+
+If you are a C-shell user, the `source activate` command below
+will not work, as that script only supports `bash` and `zsh`. A workaround is to switch to a `bash` shell at this point (by typing 
+`bash`), and then stay in that `bash` shell to do the other two commands below. It's not really a workaround though - because you 
+will have to come back to `bash` and re-do this environment set-up every time you want to use the LSST software anyway.
 
 .. code-block:: bash
 
-   source ${HOME}/miniconda2/bin/activate lsst
+   source activate lsst
    conda install lsst-distrib lsst-sims
    source eups-setups.sh
 
@@ -60,8 +63,7 @@ You should now be set up to use the DM Stack in the current `bash` shell.
 Set Up Environment to Use LSST Code
 -----------------------------------
 Every time you start a new shell, you need to set up its environment to enable use of the LSST code. The following lines could be 
-worth adding to your `.bashrc` file or equivalent.
-C-shell users would use `eups_setup.csh` and `setenv` in their `.login` file.
+worth adding to your `~/.bash_profile` file or equivalent.
 
 .. code-block:: bash
 
@@ -71,6 +73,15 @@ C-shell users would use `eups_setup.csh` and `setenv` in their `.login` file.
    source eups-setups.sh
    setup obs_lsstSim
    setup lsst_sims
+
+C-shell users: there doesn't seem to be a way round using `bash` when working with LSST software. Once you have added the above lines 
+to a file called `~/.bash_profile`, you can make an alias that starts a login `bash` shell and executes this `~/.bash_profile`. In your 
+`~/.cshrc` file, add:
+
+.. code-block:: csh
+
+    alias LSST "bash -l"
+    echo "Type 'LSST' to set up the LSST environment"
 
 
 Install Optional Python Modules Not Included with DMStack

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -10,7 +10,7 @@ Sims tools (among other things). Here's how to get everything working.
 Get Anaconda Python
 --------------------------------
 
-Click [here](http://conda.pydata.org/miniconda.html) and download python 
+Click `here <http://conda.pydata.org/miniconda.html>`_ and download python 
 2.7, if you don't have Anaconda python already.
 
 ```
@@ -23,7 +23,7 @@ your default version of python.
 Install the LSST DM Stack and LSST Sims Tools
 --------------------------
 These instructions come from the `LSST Science
-Pipelines<https://pipelines.lsst.io/install/conda.html>`
+Pipelines <https://pipelines.lsst.io/install/conda.html>`_
 
 These commands will download and activate the LSST Science Pipelines in a 
 new Conda environment named "lsst":
@@ -59,8 +59,63 @@ file.
 
 Install Optional Python Modules Not Included with DMStack
 ----------------------------
+
 .. code-block:: bash
+
     conda install nose
     conda install coverge
     conda install iminuit
+    
+Install PhoSim
+-----------------------
+The PhoSim Confluence page is available `here <https://confluence.lsstcorp.org/display/PHOSIM>`_.
+     
+.. code-block:: bash
+
+    mkdir ~/repos
+    cd ~/repos
+    git clone https://stash.lsstcorp.org/scm/sim/sims_phosim.git
+    setup cfitsio
+    setup fftw
+    ./configure
+    make
+
+You'll have to point to the correct cfitsio and fftw3 libraries and headers for your system.
+
+Test `PhoSim`
+---------------
+
+.. code-block:: bash
+
+    mkdir ~/TwinklesData
+    cd ~/TwinklesData
+    python $SIMS_CATUTILS_DIR/examples/generatePhosimInput.py
+    ./phosim ~/TwinklesData/phoSim_example.txt --sensor="R22_S11" -c examples/nobackground
+
+This produces a file `PhoSim` can run.
+Images show up in the "output" directory.
+
+
+Gravitational Lens Sprinkling Setup
+---------------------------------------
+
+#. Follow instructions above to setup DM Stack and LSST Sims
+
+#. Install and setup `OM10 <https://github.com/drphilmarshall/OM10>`_.
+
+#. Open an SSH tunnel for database connection to UW. See
+`here <https://confluence.lsstcorp.org/display/SIM/Accessing+the+UW+CATSIM+Database>`_ for more information.
+This is where the objects that will populate the catalog are stored.
+
+#. You'll also need the OpSim sqlite repository from `this page <https://confluence.lsstcorp.org/display/SIM/OpSim+Datasets+for+Cadence+Workshop+LSST2015>`_
+
+#. Now you're ready to go with:
+
+.. code-block:: bash
+
+    python generatePhosimInput.py
+
+
+Supernova Sprinkling Setup
+---------------------------
 

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -7,7 +7,6 @@ This page contains our notes on how to set your Mac laptop up to run the LSST DM
 .. contents::
    :depth: 4
 
-Please check the "Important Installation Notes" to view current mitigations for known installation issues.
 
 DM Stack and Sims Installation
 ================================
@@ -84,8 +83,8 @@ Install Optional Python Modules Not Included with DMStack
     conda install iminuit
 
 
-Important Installation Notes
-----------------------------
+Important DM Stack Installation Notes
+-------------------------------------
 - 2016 July 8
     The `12_0` released version of `sims_utils` is incompatible with the `astropy` 1.2.1.  You'll need to downgrade `astropy` after completing your DM Stack installation:
 
@@ -132,6 +131,11 @@ Test `PhoSim`
 This produces a file `PhoSim` can run.
 Images show up in the "output" directory.
 
+
+Twinkles-specific Installation Notes
+====================================
+The notes above should be helpful for anyone looking to use either the Stack or the Sims tools, or both. We now turn to the 
+additional code needed by the Twinkles project, to sprinkle in the twinkly objects.
 
 Gravitational Lens Sprinkling Setup
 ---------------------------------------

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -18,9 +18,10 @@ Get Anaconda Python
 Click `here <http://conda.pydata.org/miniconda.html>`_ and download python 
 2.7, if you don't have Anaconda python already.
 
-```
+.. code-block:: bash
+
 bash ~/Downloads/Miniconda-latest-MacOSX-x86_64.sh
-```
+
 This installs miniconda into `${HOME}/miniconda2` by default. You should i
 now pre-pend your `PATH` with `${HOME}/miniconda2/bin` so that this becomes
 your default version of python.

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -24,7 +24,7 @@ Click `here <http://conda.pydata.org/miniconda.html>`_ and download python
 
     bash ~/Downloads/Miniconda-latest-MacOSX-x86_64.sh
 
-This installs miniconda into `${HOME}/miniconda2` by default. You should i
+This installs miniconda into `${HOME}/miniconda2` by default. You should 
 now pre-pend your `PATH` with `${HOME}/miniconda2/bin` so that this becomes
 your default version of python.
 
@@ -44,7 +44,7 @@ new Conda environment named "lsst":
 
    conda config --add channels http://conda.lsst.codes/stack  
    conda create --name lsst python=2
-   source activate lsst
+   source ${HOME}/miniconda2/bin/activate lsst
    conda install lsst-distrib lsst-sims
    source eups-setups.sh
 
@@ -61,7 +61,7 @@ C-shell users would use `eups_setup.csh` and `setenv` in their `.login` file.
 
    export LSST_DIR = ${HOME}/miniconda2
    set path = (${LSST_DIR}/bin $path)
-   source activate lsst
+   source ${LSST_DIR}/bin/activate lsst
    source eups-setups.sh
    setup obs_lsstSim
    setup lsst_sims

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -9,7 +9,7 @@ This page contains our notes on how to set your Mac laptop up to run the LSST DM
 
 Please check the "Important Installation Notes" to view current mitigations for known installation issues.
 
-Installation
+DM Stack and Sims Installation
 ================================
 The Twinkles package uses the LSST DM Stack's `afw` code, and also the LSST
 Sims tools (among other things). Here's how to get everything working.
@@ -82,10 +82,22 @@ Install Optional Python Modules Not Included with DMStack
     conda install nose
     conda install coverage
     conda install iminuit
+
+
+Important Installation Notes
+----------------------------
+- 2016 July 8
+    The `12_0` released version of `sims_utils` is incompatible with the `astropy` 1.2.1.  You'll need to downgrade `astropy` after completing your DM Stack installation:
+
+.. code-block:: bash
+
+    conda install astropy=1.1.2
+
     
-Install PhoSim
------------------------
-The PhoSim Confluence page is available `here <https://confluence.lsstcorp.org/display/PHOSIM>`_. The code is available 
+PhoSim Installation
+================================
+`PhoSim` is not distributed with the rest of the LSST sims tools, but is readily available as an independent package. 
+The PhoSim confluence page is available `here <https://confluence.lsstcorp.org/display/PHOSIM>`_. The code is obtained 
 from LSST via `git`, and needs the `cfitsio` and `fftw3` libraries: you'll be asked to point to their locations by the `PhoSim` 
 configure script, or if you can't, it will offer to install them for you from source.
      
@@ -146,11 +158,3 @@ Supernova Sprinkling Setup
 Coming soon!
 
 
-Important Installation Notes
----------------
-- 2016 July 8
-    The 12_0 released version of sims_utils is incompatible with the astropy 1.2.1.  Users need to downgrade astropy after completing their DMStack installation.
-
-.. code-block:: bash
-
-    conda install astropy=1.1.2

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -20,7 +20,7 @@ Click `here <http://conda.pydata.org/miniconda.html>`_ and download python
 
 .. code-block:: bash
 
-bash ~/Downloads/Miniconda-latest-MacOSX-x86_64.sh
+    bash ~/Downloads/Miniconda-latest-MacOSX-x86_64.sh
 
 This installs miniconda into `${HOME}/miniconda2` by default. You should i
 now pre-pend your `PATH` with `${HOME}/miniconda2/bin` so that this becomes

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -37,7 +37,6 @@ These commands will download and activate the current release versions of the LS
 new Conda environment named "lsst":
 
 .. code-block:: bash
-      :linenos:
 
    conda config --add channels http://conda.lsst.codes/stack  
    conda create --name lsst python=2

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -31,9 +31,13 @@ your default version of python.
 Install the LSST DM Stack and LSST Sims Tools
 ---------------------------------------------
 These instructions come from the `LSST Science
-Pipelines <https://pipelines.lsst.io/install/conda.html>`_
+Pipelines <https://pipelines.lsst.io/install/conda.html>`_. The first thing that they recommend is to make sure `conda` is up to date:
 
-These commands will download and activate the current release versions of the LSST Science Pipelines in a 
+.. code-block:: bash
+
+   conda update conda
+
+The following commands will download and activate the current release versions of the LSST Science Pipelines in a 
 new Conda environment named "lsst":
 
 .. code-block:: bash

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -2,7 +2,12 @@
 Getting Started on your Laptop
 ################################
 
-Installation Notes
+.. contents::
+   :depth: 4
+
+Please check the "Important Installation Notes" to view current mitigations for known installation issues.
+
+Installation
 ================================
 The Twinkles package uses the LSST DM Stack's `afw` code, and also the LSST
 Sims tools (among other things). Here's how to get everything working.
@@ -21,11 +26,11 @@ now pre-pend your `PATH` with `${HOME}/miniconda2/bin` so that this becomes
 your default version of python.
 
 Install the LSST DM Stack and LSST Sims Tools
---------------------------
+---------------------------------------------
 These instructions come from the `LSST Science
 Pipelines <https://pipelines.lsst.io/install/conda.html>`_
 
-These commands will download and activate the LSST Science Pipelines in a 
+These commands will download and activate the current release versions of the LSST Science Pipelines in a 
 new Conda environment named "lsst":
 
 .. code-block:: bash
@@ -119,3 +124,12 @@ This is where the objects that will populate the catalog are stored.
 Supernova Sprinkling Setup
 ---------------------------
 
+
+Important Installation Notes
+---------------
+- 2016 July 8
+    The 12_0 released version of sims_utils is incompatible with the astropy 1.2.1.  Users need to downgrade astropy after completing their DMStack installation.
+
+.. code-block:: bash
+
+    conda install astropy=1.1.2

--- a/doc/Setup/Getting_started_on_your_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_laptop.rst
@@ -1,0 +1,66 @@
+################################
+Getting Started on your Laptop
+################################
+
+Installation Notes
+================================
+The Twinkles package uses the LSST DM Stack's `afw` code, and also the LSST
+Sims tools (among other things). Here's how to get everything working.
+
+Get Anaconda Python
+--------------------------------
+
+Click [here](http://conda.pydata.org/miniconda.html) and download python 
+2.7, if you don't have Anaconda python already.
+
+```
+bash ~/Downloads/Miniconda-latest-MacOSX-x86_64.sh
+```
+This installs miniconda into `${HOME}/miniconda2` by default. You should i
+now pre-pend your `PATH` with `${HOME}/miniconda2/bin` so that this becomes
+your default version of python.
+
+Install the LSST DM Stack and LSST Sims Tools
+--------------------------
+These instructions come from the `LSST Science
+Pipelines<https://pipelines.lsst.io/install/conda.html>`
+
+These commands will download and activate the LSST Science Pipelines in a 
+new Conda environment named "lsst":
+
+.. code-block:: bash
+      :linenos:
+
+   conda config --add channels http://conda.lsst.codes/stack  
+   conda create --name lsst python=2
+   source activate lsst
+   conda install lsst-distrib lsst-sims
+   source eups-setups.sh
+
+
+You are now set up to use the DM Stack in the current shell.
+
+Environment Set up to Use LSST Code
+-------------------------------------
+
+.. code-block:: bash
+
+   export LSST_DIR = ${HOME}/miniconda2
+   set path = (${LSST_DIR}/bin $path)
+   source activate lsst
+   source eups-setups.sh
+   setup obs_lsstSim
+   setup lsst_sims
+
+This needs to be done every time you start a new shell - so these lines 
+could be worth adding to your `.bashrc` file or equivalent. Note that 
+c-shell users can use `eups_setup.csh` and use `setenv` in their `.login` 
+file.
+
+Install Optional Python Modules Not Included with DMStack
+----------------------------
+.. code-block:: bash
+    conda install nose
+    conda install coverge
+    conda install iminuit
+

--- a/doc/Setup/Getting_started_on_your_linux_laptop.rst
+++ b/doc/Setup/Getting_started_on_your_linux_laptop.rst
@@ -1,0 +1,148 @@
+##################################
+Getting Started on a Linux Laptop
+##################################
+
+This page contains our notes on how to set your Linux laptop up to run the LSST DM stack and sims tools. 
+
+.. contents::
+   :depth: 4
+
+Please check the "Important Installation Notes" to view current mitigations for known installation issues.
+
+Installation
+================================
+The Twinkles package uses the LSST DM Stack's `afw` code, and also the LSST
+Sims tools (among other things). Here's how to get everything working.
+
+Get Anaconda Python
+--------------------------------
+
+Click `here <http://conda.pydata.org/miniconda.html>`_ and download python 
+2.7, if you don't have Anaconda python already.
+
+.. code-block:: bash
+
+    bash ./Miniconda-latest-Linux-x86_64.sh
+
+This installs miniconda into `${HOME}/miniconda2` by default. You should 
+now pre-pend your `PATH` with `${HOME}/miniconda2/bin` so that this becomes
+your default version of python.
+
+Install the LSST DM Stack and LSST Sims Tools
+---------------------------------------------
+These instructions come from the `LSST Science
+Pipelines <https://pipelines.lsst.io/install/conda.html>`_. The first thing that they recommend is to make sure `conda` is up to date:
+
+.. code-block:: bash
+
+   conda update conda
+
+The following commands will download and activate the current release versions of the LSST Science Pipelines in a 
+new Conda environment named "lsst". At various times they need to to type "`y`", so unfortunately you cannot leave them too long. They 
+each take a few minutes, except for the `conda install`, which takes about an hour.  
+
+.. code-block:: bash
+
+   conda config --add channels http://conda.lsst.codes/stack  
+   conda create --name lsst python=2
+   
+You are now ready to install the `lsst` software. If you are a C-shell user, the `source activate` command below
+will not work, as that script only supports `bash` and `zsh`. A workaround is to switch to a `bash` shell at this point, 
+and then stay in that bash shell to do the other two commands below.
+
+.. code-block:: bash
+
+   source activate lsst
+   conda install lsst-distrib lsst-sims
+   source eups-setups.sh
+
+You should now be set up to use the DM Stack in the current `bash` shell.
+
+Set Up Environment to Use LSST Code
+-----------------------------------
+Every time you start a new shell, you need to set up its environment to enable use of the LSST code. The following lines could be 
+worth adding to your `.bashrc` file or equivalent.
+C-shell users would use `eups_setup.csh` and `setenv` in their `.login` file.
+
+.. code-block:: bash
+
+   export LSST_DIR = ${HOME}/miniconda2
+   set path = (${LSST_DIR}/bin $path)
+   source ${LSST_DIR}/bin/activate lsst
+   source eups-setups.sh
+   setup obs_lsstSim
+   setup lsst_sims
+
+
+Install Optional Python Modules Not Included with DMStack
+----------------------------
+
+.. code-block:: bash
+
+    conda install nose
+    conda install coverage
+    conda install iminuit
+    
+Install PhoSim
+-----------------------
+The PhoSim Confluence page is available `here <https://confluence.lsstcorp.org/display/PHOSIM>`_.
+     
+.. code-block:: bash
+
+    mkdir ~/repos
+    cd ~/repos
+    git clone https://stash.lsstcorp.org/scm/sim/sims_phosim.git
+    setup cfitsio
+    setup fftw
+    ./configure
+    make
+
+You'll have to point to the correct cfitsio and fftw3 libraries and headers for your system.
+
+Test `PhoSim`
+---------------
+
+.. code-block:: bash
+
+    mkdir ~/TwinklesData
+    cd ~/TwinklesData
+    python $SIMS_CATUTILS_DIR/examples/generatePhosimInput.py
+    ./phosim ~/TwinklesData/phoSim_example.txt --sensor="R22_S11" -c examples/nobackground
+
+This produces a file `PhoSim` can run.
+Images show up in the "output" directory.
+
+
+Gravitational Lens Sprinkling Setup
+---------------------------------------
+
+#. Follow instructions above to setup DM Stack and LSST Sims
+
+#. Install and setup `OM10 <https://github.com/drphilmarshall/OM10>`_.
+
+#. Open an SSH tunnel for database connection to UW. See
+`here <https://confluence.lsstcorp.org/display/SIM/Accessing+the+UW+CATSIM+Database>`_ for more information.
+This is where the objects that will populate the catalog are stored.
+
+#. You'll also need the OpSim sqlite repository from `this page <https://confluence.lsstcorp.org/display/SIM/OpSim+Datasets+for+Cadence+Workshop+LSST2015>`_
+
+#. Now you're ready to go with:
+
+.. code-block:: bash
+
+    python generatePhosimInput.py
+
+
+Supernova Sprinkling Setup
+---------------------------
+Coming soon!
+
+
+Important Installation Notes
+---------------
+- 2016 July 8
+    The 12_0 released version of sims_utils is incompatible with the astropy 1.2.1.  Users need to downgrade astropy after completing their DMStack installation.
+
+.. code-block:: bash
+
+    conda install astropy=1.1.2


### PR DESCRIPTION
I am following the [instructions from Heather](https://github.com/DarkEnergyScienceCollaboration/Twinkles/blob/issue/160/installation/doc/Setup/Getting_started_on_your_laptop.rst), and editing them as I go. Here's the growing list of feedback items I am generating, to be addressed:

* [x] Instructions are mac-specific, I point this out

* [x] `conda create  --name lsst python=2` generates two (apparently non-destructive) errors: 
`SSL verification error: [SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:590)`

* [x] `conda create` does not complete fully, for me: 
`No psutil available.
To proceed, please conda install psutil#` I did this before carrying on, with apparently no ill effects.

* [x] `source activate lsst` only works if you are in `${HOME}/miniconda/bin` - I changed the instructions to use the full path

* [x] The `activate` command fails, with error
`BASH_VERSION: Undefined variable.`
I am a C-shell user. I had to switch to `bash` to complete the installation - I added notes on this.

* [x] Maybe we should recommend `bash` further up? I need to check that things work when I switch back to `tcsh` though... and they don't. Instructions are now correct regarding use of c-shell.

* [x] The PhoSim test fails if you don't have access to the CatSim database at UW. This is a pretty stringent test, but hey - that's what it takes to run Twinkles on your laptop. I added notes on this.