### PR TITLE
output galaxy position angles in radians

### DIFF
--- a/python/desc/twinkles/InstcatGenerator.py
+++ b/python/desc/twinkles/InstcatGenerator.py
@@ -11,8 +11,9 @@ from lsst.sims.catalogs.generation.db import CatalogDBObject
 from lsst.sims.catalogs.measures.instance import CompoundInstanceCatalog
 from lsst.sims.catUtils.baseCatalogModels import GalaxyTileCompoundObj
 from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import \
-        PhoSimCatalogPoint, PhoSimCatalogSersic2D, PhoSimCatalogZPoint
+        PhoSimCatalogPoint, PhoSimCatalogZPoint
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
+from desk.twinkles.twinklesCatalogDefs import TwinklesCatalogSersic2D
 from .sprinkler import sprinklerCompound
 
 class InstcatFactory(object):
@@ -42,8 +43,8 @@ class InstcatGenerator(object):
                         'cepheidstars']
         for objid in starObjNames:
             self.update_factories(objid, PhoSimCatalogPoint)
-        self.update_factories('galaxyBulge', PhoSimCatalogSersic2D)
-        self.update_factories('galaxyDisk', PhoSimCatalogSersic2D)
+        self.update_factories('galaxyBulge', TwinklesCatalogSersic2D)
+        self.update_factories('galaxyDisk', TwinklesCatalogSersic2D)
         self.update_factories('galaxyAgn', PhoSimCatalogZPoint)
 
     def update_factories(self, objid, catobj):

--- a/python/desc/twinkles/generatePhosimInput.py
+++ b/python/desc/twinkles/generatePhosimInput.py
@@ -24,10 +24,10 @@ from lsst.sims.catUtils.baseCatalogModels import (StarObj, CepheidStarObj,
                                                   GalaxyAgnObj, SNDBObj)
 # from lsst.sims.catUtils.mixins import FrozenSNCat
 from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import \
-        PhoSimCatalogPoint, PhoSimCatalogSersic2D, PhoSimCatalogSN, \
+        PhoSimCatalogPoint, PhoSimCatalogSN, \
         DefaultPhoSimHeaderMap
 from desc.twinkles.sprinkler import sprinklerCompound
-from desc.twinkles.twinklesCatalogDefs import TwinklesCatalogZPoint
+from desc.twinkles.twinklesCatalogDefs import TwinklesCatalogZPoint, TwinklesCatalogSersic2D
 
 PhoSimHeaderMap = {'rottelpos': ('rotTelPos', np.degrees),
                    'obshistid': ('obsHistID', None),
@@ -114,7 +114,7 @@ def generatePhosimInput(mode='a', obsHistIdList=None, opsimDB='kraken_1042_sqlit
         compoundGalDBList = [GalaxyBulgeObj, GalaxyDiskObj, GalaxyAgnObj]
 
         compoundStarICList = [PhoSimCatalogPoint, PhoSimCatalogPoint]
-        compoundGalICList = [PhoSimCatalogSersic2D, PhoSimCatalogSersic2D,
+        compoundGalICList = [TwinklesCatalogSersic2D, TwinklesCatalogSersic2D,
                              TwinklesCatalogZPoint]
 
         snphosim = PhoSimCatalogSN(db_obj=snmodel,

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -7,6 +7,7 @@ from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import PhosimInputBase
 from lsst.sims.catUtils.mixins import PhoSimAstrometryGalaxies, \
                                       EBVmixin, VariabilityStars
+from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D
 from .twinklesVariabilityMixins import VariabilityTwinkles
 
 class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin, VariabilityTwinkles):
@@ -26,3 +27,8 @@ class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin,
     delimiter = " "
     spatialModel = "point"
     transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees}
+
+
+class TwinklesCatalogSersic2D(PhoSimCatalogSersic2D):
+    transformations = {'raPhoSim': numpy.degrees, 'decPhoSim': numpy.degrees,
+                       'majorAxis': arcsecFromRadians, 'minorAxis': arcsecFromRadians}

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -17,11 +17,10 @@ from lsst.sims.catUtils.baseCatalogModels import (StarObj,
 from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
 from lsst.sims.catUtils.exampleCatalogDefinitions import\
     (PhoSimCatalogPoint,
-     PhoSimCatalogSersic2D,
      PhoSimCatalogSN,
      DefaultPhoSimHeaderMap,
      DefaultPhoSimInstanceCatalogCols)
-from .twinklesCatalogDefs import TwinklesCatalogZPoint
+from .twinklesCatalogDefs import TwinklesCatalogZPoint, TwinklesCatalogSersic2D
 from .sprinkler import sprinklerCompound
 
 __all__ = ['TwinklesPhoSimHeader', 'TwinklesSky']
@@ -94,7 +93,7 @@ class TwinklesSky(object):
 
         # Galaxies
         self.compoundGalDBList = [GalaxyBulgeObj, GalaxyDiskObj, GalaxyAgnObj]
-        self.compoundGalICList = [PhoSimCatalogSersic2D, PhoSimCatalogSersic2D,
+        self.compoundGalICList = [TwinklesCatalogSersic2D, TwinklesCatalogSersic2D,
                                   TwinklesCatalogZPoint]
 
         # SN 


### PR DESCRIPTION
Chris Walter just pointed out that CatSim outputs galaxy position
angles in degrees, while PhoSim wants radians.  Rather than fix
CatSim (which will happen shortly), I added a new catalog class to
twinklesCatalogDefs which inherits from PhoSimCatalogSersic2D, but
overwrites the 'transformations' dict so that position angle is now
output in radians.