### PR TITLE
Issue#351/spectra file name defs

### DIFF
--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -1,6 +1,7 @@
 """Instance Catalog"""
 from __future__ import absolute_import, division, print_function
 import numpy
+import numpy as np
 from lsst.sims.utils import SpecMap, defaultSpecMap
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.utils import arcsecFromRadians
@@ -39,9 +40,18 @@ class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
     def get_shorterFileNames(self):
         fnames = self.column_by_name('sedFilepath')
         sep = 'spectra_files/specFile_'
-        split_names = list(sep + fname.split(sep)[-1] for fname in fnames)
-        return split_names
+        split_names = []
+        for fname in fnames:
+            if 'None' not in fname:
+                fname = sep + fname.split(sep)[-1] 
+            else:
+                fname = 'None'
+            split_names.append(fname)
+        return np.array(split_names)
 
     column_outputs = PhoSimCatalogSN.column_outputs
     column_outputs[PhoSimCatalogSN.column_outputs.index('sedFilepath')] = \
         'shorterFileNames'
+
+    cannot_be_null = ['x0', 't0', 'z', 'shorterFileNames']
+

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -4,7 +4,8 @@ import numpy
 from lsst.sims.utils import SpecMap, defaultSpecMap
 from lsst.sims.catalogs.definitions import InstanceCatalog
 from lsst.sims.utils import arcsecFromRadians
-from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import PhosimInputBase
+from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples \
+        import PhosimInputBase, PhoSimCatalogSN
 from lsst.sims.catUtils.mixins import PhoSimAstrometryGalaxies, \
                                       EBVmixin, VariabilityStars
 from .twinklesVariabilityMixins import VariabilityTwinkles
@@ -41,5 +42,6 @@ class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
         split_names = list(sep + fname.split(sep)[-1] for fname in fnames)
         return split_names
 
-    self.column_outputs[self.column_outputs.index('sedFilepath')] = \
-            shorterFileNames
+    column_outputs = PhoSimCatalogSN.column_outputs
+    column_outputs[PhoSimCatalogSN.column_outputs.index('sedFilepath')] = \
+        'shorterFileNames'

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -8,7 +8,10 @@ from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import P
 from lsst.sims.catUtils.mixins import PhoSimAstrometryGalaxies, \
                                       EBVmixin, VariabilityStars
 from .twinklesVariabilityMixins import VariabilityTwinkles
-__all__ = ['TwinklesCatalogZPoint']
+
+
+__all__ = ['TwinklesCatalogZPoint', 'TwinklesPhoSimCatalogSN']
+
 class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin, VariabilityTwinkles):
 
     catalog_type = 'twinkles_catalog_ZPOINT'
@@ -26,3 +29,17 @@ class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin,
     delimiter = " "
     spatialModel = "point"
     transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees}
+
+class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
+    """
+    Modification of the PhoSimCatalogSN mixin to provide shorter sedFileNames
+    by leaving out the parts of the directory name 
+    """
+    def get_shorterFileNames(self):
+        fnames = self.column_by_name('sedFilepath')
+        sep = 'spectra_files/specFile_'
+        split_names = list(sep + fname.split(sep)[-1] for fname in fnames)
+        return split_names
+
+    self.column_outputs[self.column_outputs.index('sedFilepath')] = \
+            shorterFileNames

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -1,6 +1,5 @@
 """Instance Catalog"""
 from __future__ import absolute_import, division, print_function
-import numpy
 import numpy as np
 from lsst.sims.utils import SpecMap, defaultSpecMap
 from lsst.sims.catalogs.definitions import InstanceCatalog
@@ -30,7 +29,7 @@ class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin,
     default_formats = {'S':'%s', 'f':'%.9g', 'i':'%i'}
     delimiter = " "
     spatialModel = "point"
-    transformations = {'raPhoSim':numpy.degrees, 'decPhoSim':numpy.degrees}
+    transformations = {'raPhoSim':np.degrees, 'decPhoSim':np.degrees}
 
 class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
     """

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -8,7 +8,7 @@ from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import P
 from lsst.sims.catUtils.mixins import PhoSimAstrometryGalaxies, \
                                       EBVmixin, VariabilityStars
 from .twinklesVariabilityMixins import VariabilityTwinkles
-
+__all__ = ['TwinklesCatalogZPoint']
 class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin, VariabilityTwinkles):
 
     catalog_type = 'twinkles_catalog_ZPOINT'

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -19,10 +19,10 @@ from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
 from lsst.sims.catUtils.exampleCatalogDefinitions import\
     (PhoSimCatalogPoint,
      PhoSimCatalogSersic2D,
-     PhoSimCatalogSN,
      DefaultPhoSimHeaderMap,
      DefaultPhoSimInstanceCatalogCols)
 from .twinklesCatalogDefs import TwinklesCatalogZPoint
+from .twinklesCatalogDefs import TwinklesPhoSimCatalogSN as PhoSimCatalogSN
 from desc.twinkles import (GalaxyCacheDiskObj, GalaxyCacheBulgeObj,
                            GalaxyCacheAgnObj, GalaxyCacheSprinklerObj,
                            create_galaxy_cache,


### PR DESCRIPTION
The PhoSim Instance Catalogs outputs a string to the path of the spectra files relative to `seddir` argument supplied to the `bin/generatePhoSimInstanceCatalog.py`  rather than the absolute path. 
 
`TwinklesSky` now uses `TwinklesPhoSimCatalogSN` rather than `PhoSimCatalogSN` directly. 
`TwinklesPhoSimCatalogSN` inherits from `PhoSimCatalogSN`, but 
- defines a getter for `shorterFileNames` which is `sedFilepath` with prepended seddir stripped as requested.
- redefine `column_outputs` to include `shorterFileNames` rather than `sedFilepath`

 

Fixes #351 