### PR TITLE
Fix merges

### DIFF
--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogZPoint
 from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import PhoSimCatalogSN
+import numpy as np
 from .twinklesVariabilityMixins import VariabilityTwinkles
 __all__ = ['TwinklesCatalogZPoint', 'TwinklesPhoSimCatalogSN']
 
@@ -20,9 +21,18 @@ class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
     def get_shorterFileNames(self):
         fnames = self.column_by_name('sedFilepath')
         sep = 'spectra_files/specFile_'
-        split_names = list(sep + fname.split(sep)[-1] for fname in fnames)
-        return split_names
+        split_names = []
+        for fname in fnames:
+            if 'None' not in fname:
+                fname = sep + fname.split(sep)[-1] 
+            else:
+                fname = 'None'
+            split_names.append(fname)
+        return np.array(split_names)
 
     column_outputs = PhoSimCatalogSN.column_outputs
     column_outputs[PhoSimCatalogSN.column_outputs.index('sedFilepath')] = \
         'shorterFileNames'
+
+    cannot_be_null = ['x0', 't0', 'z', 'shorterFileNames']
+

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -1,10 +1,9 @@
 """PhoSim Instance Catalog"""
 from __future__ import absolute_import, division, print_function
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogZPoint
+from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import PhoSimCatalogSN
 from .twinklesVariabilityMixins import VariabilityTwinkles
 __all__ = ['TwinklesCatalogZPoint', 'TwinklesPhoSimCatalogSN']
-
-class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin, VariabilityTwinkles):
 
 class TwinklesCatalogZPoint(PhoSimCatalogZPoint, VariabilityTwinkles):
     """
@@ -24,5 +23,6 @@ class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
         split_names = list(sep + fname.split(sep)[-1] for fname in fnames)
         return split_names
 
-    self.column_outputs[self.column_outputs.index('sedFilepath')] = \
-            shorterFileNames
+    column_outputs = PhoSimCatalogSN.column_outputs
+    column_outputs[PhoSimCatalogSN.column_outputs.index('sedFilepath')] = \
+        'shorterFileNames'

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -30,9 +30,13 @@ class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
             split_names.append(fname)
         return np.array(split_names)
 
-    column_outputs = PhoSimCatalogSN.column_outputs
-    column_outputs[PhoSimCatalogSN.column_outputs.index('sedFilepath')] = \
-        'shorterFileNames'
+    # column_outputs = PhoSimCatalogSN.column_outputs
+    # column_outputs[PhoSimCatalogSN.column_outputs.index('sedFilepath')] = \
+    #    'shorterFileNames'
 
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'shorterFileNames',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'galacticExtinctionModel', 'galacticAv', 'galacticRv',
+                      'internalExtinctionModel']
     cannot_be_null = ['x0', 't0', 'z', 'shorterFileNames']
 

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -33,10 +33,10 @@ class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
     # column_outputs = PhoSimCatalogSN.column_outputs
     # column_outputs[PhoSimCatalogSN.column_outputs.index('sedFilepath')] = \
     #    'shorterFileNames'
-
-    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'shorterFileNames',
-                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
-                      'spatialmodel', 'galacticExtinctionModel', 'galacticAv', 'galacticRv',
-                      'internalExtinctionModel']
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim',
+                      'phoSimMagNorm', 'shorterFileNames', 'redshift',
+                      'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'internalExtinctionModel',
+                      'galacticExtinctionModel', 'galacticAv', 'galacticRv']
     cannot_be_null = ['x0', 't0', 'z', 'shorterFileNames']
 

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -1,13 +1,11 @@
 """PhoSim Instance Catalog"""
 from __future__ import absolute_import, division, print_function
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogZPoint
-from twinklesVariabilityMixins import VariabilityTwinkles
-import numpy
+from .twinklesVariabilityMixins import VariabilityTwinkles
 
 class TwinklesCatalogZPoint(PhoSimCatalogZPoint, VariabilityTwinkles):
     """
     PhoSim Instance Catalog Class for strongly lensed (and therefore time-delayed)
     AGN
     """
-
     catalog_type = 'twinkles_catalog_ZPOINT'

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -2,6 +2,9 @@
 from __future__ import absolute_import, division, print_function
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogZPoint
 from .twinklesVariabilityMixins import VariabilityTwinkles
+__all__ = ['TwinklesCatalogZPoint', 'TwinklesPhoSimCatalogSN']
+
+class TwinklesCatalogZPoint(PhosimInputBase, PhoSimAstrometryGalaxies, EBVmixin, VariabilityTwinkles):
 
 class TwinklesCatalogZPoint(PhoSimCatalogZPoint, VariabilityTwinkles):
     """
@@ -9,3 +12,17 @@ class TwinklesCatalogZPoint(PhoSimCatalogZPoint, VariabilityTwinkles):
     AGN
     """
     catalog_type = 'twinkles_catalog_ZPOINT'
+
+class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
+    """
+    Modification of the PhoSimCatalogSN mixin to provide shorter sedFileNames
+    by leaving out the parts of the directory name 
+    """
+    def get_shorterFileNames(self):
+        fnames = self.column_by_name('sedFilepath')
+        sep = 'spectra_files/specFile_'
+        split_names = list(sep + fname.split(sep)[-1] for fname in fnames)
+        return split_names
+
+    self.column_outputs[self.column_outputs.index('sedFilepath')] = \
+            shorterFileNames

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -22,7 +22,7 @@ from lsst.sims.catUtils.exampleCatalogDefinitions import\
      DefaultPhoSimHeaderMap,
      DefaultPhoSimInstanceCatalogCols)
 from .twinklesCatalogDefs import TwinklesCatalogZPoint
-from .twinklesCatalogDefs import TwinklesPhoSimCatalogSN as PhoSimCatalogSN
+from .twinklesCatalogDefs import TwinklesPhoSimCatalogSN
 from desc.twinkles import (GalaxyCacheDiskObj, GalaxyCacheBulgeObj,
                            GalaxyCacheAgnObj, GalaxyCacheSprinklerObj,
                            create_galaxy_cache,
@@ -165,8 +165,8 @@ class TwinklesSky(object):
                              write_header=False)
 
         t_after_galCat = time.time()
-        snphosim = PhoSimCatalogSN(db_obj=self.snObj,
-                                        obs_metadata=self.obs_metadata)
+        snphosim = TwinklesPhoSimCatalogSN(db_obj=self.snObj,
+                                           obs_metadata=self.obs_metadata)
         ### Set properties
         snphosim.writeSedFile = True
         snphosim.suppressDimSN = True

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -19,10 +19,10 @@ from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
 from lsst.sims.catUtils.exampleCatalogDefinitions import\
     (PhoSimCatalogPoint,
      PhoSimCatalogSersic2D,
-     PhoSimCatalogSN,
      DefaultPhoSimHeaderMap,
      DefaultPhoSimInstanceCatalogCols)
 from .twinklesCatalogDefs import TwinklesCatalogZPoint
+from .twinklesCatalogDefs import TwinklesPhoSimCatalogSN as PhoSimCatalogSN
 from desc.twinkles import (GalaxyCacheDiskObj, GalaxyCacheBulgeObj,
                            GalaxyCacheAgnObj, GalaxyCacheSprinklerObj,
                            create_galaxy_cache,


### PR DESCRIPTION
Testing the PR for the merge. (The previous branch was muddled in a merge)

The PhoSim Instance Catalogs outputs a string to the path of the spectra files relative to seddir argument supplied to the bin/generatePhoSimInstanceCatalog.py rather than the absolute path.

TwinklesSky now uses TwinklesPhoSimCatalogSN rather than PhoSimCatalogSN directly. 
TwinklesPhoSimCatalogSN inherits from PhoSimCatalogSN, but

defines a getter for shorterFileNames which is sedFilepath with prepended seddir stripped as requested.
redefine column_outputs to include shorterFileNames rather than sedFilepath
Fixes #351
