### PR TITLE
write InstanceCatalogClasses to fix the order of rest/lab frame dust parameters

### DIFF
--- a/bin/generatePhosimInput.py
+++ b/bin/generatePhosimInput.py
@@ -8,6 +8,7 @@ import os
 import argparse
 import pandas as pd
 from sqlalchemy import create_engine
+from lsst.utils import getPackageDir
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from desc.twinkles import TwinklesSky
 
@@ -48,7 +49,8 @@ def _sql_constraint(obsHistIDList):
 def generateSinglePointing(obs_metaData, availableConns, sntable,
                            fname,
                            sn_sed_file_dir,
-                           db_config):
+                           db_config,
+                           cache_dir):
     """
     obs_metaData : instance of `lsst.sims.utils.ObservationMetaData`
         observation metadata corresponding to an OpSim pointing
@@ -58,6 +60,7 @@ def generateSinglePointing(obs_metaData, availableConns, sntable,
     sn_sed_file_dir : directory to which the SN seds corresponding to this
         phoSim metadat
     db_config : the name of a file overriding the fatboy connection information
+    cache_dir : the directory containing the source data of astrophysical objects
     """
     tstart = time.time()
     obs_metaData.boundLength = 0.3
@@ -72,7 +75,8 @@ def generateSinglePointing(obs_metaData, availableConns, sntable,
                        brightestGal_gmag_inCat=11.0,
                        sntable=sntable,
                        sn_sedfile_prefix=os.path.join(sn_sed_file_dir, 'specFile_'),
-                       db_config=db_config)
+                       db_config=db_config,
+                       cache_dir=cache_dir)
     # fname = phoSimInputFileName(obsHistID)
     # if not os.path.exists(os.path.dirname(fname)):
     #    os.makedirs(os.path.dirname(fname))
@@ -112,6 +116,9 @@ if __name__ == '__main__':
                         help='directory to contain SED files')
     parser.add_argument('--db_config', type=str, default=None,
                         help='config file overriding CatSim database connection information')
+    parser.add_argument('--cache_dir', type=str,
+                        default=os.path.join(getPackageDir('twinkles'), 'data'),
+                        help='directory containing the source data for the InstanceCatalogs')
     args = parser.parse_args()
 
     # set the filename default to a sensible value using the obsHistID
@@ -140,4 +147,5 @@ if __name__ == '__main__':
                            sntable='TwinkSN_run3',
                            fname=args.outfile,
                            sn_sed_file_dir=sn_sed_file_dir,
-                           db_config=args.db_config)
+                           db_config=args.db_config,
+                           cache_dir=args.cache_dir)

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -41,7 +41,7 @@ class TwinklesCatalogZPoint(PhoSimCatalogZPoint, VariabilityTwinkles):
                       'spatialmodel', 'internalExtinctionModel',
                       'galacticExtinctionModel', 'galacticAv', 'galacticRv']
 
-class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
+class TwinklesCatalogSN(PhoSimCatalogSN):
     """
     Modification of the PhoSimCatalogSN mixin to provide shorter sedFileNames
     by leaving out the parts of the directory name 

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -11,6 +11,9 @@ from .twinklesVariabilityMixins import VariabilityTwinkles
 __all__ = ['TwinklesCatalogZPoint', 'TwinklesPhoSimCatalogSN']
 
 
+__all__ = ["TwinklesCatalogPoint", "TwinklesCatalogSersic2D",
+           "TwinklesCatalogZPoint", "TwinklesCatalogSN"]
+
 class TwinklesCatalogPoint(PhoSimCatalogPoint):
 
     column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',

--- a/python/desc/twinkles/twinklesCatalogDefs.py
+++ b/python/desc/twinkles/twinklesCatalogDefs.py
@@ -1,13 +1,30 @@
 """PhoSim Instance Catalog"""
 from __future__ import absolute_import, division, print_function
-from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogZPoint
-from lsst.sims.catUtils.exampleCatalogDefinitions.phoSimCatalogExamples import PhoSimCatalogSN
 import numpy as np
+from lsst.sims.catUtils.exampleCatalogDefinitions import (PhoSimCatalogZPoint,
+                                                          PhoSimCatalogPoint,
+                                                          PhoSimCatalogSersic2D,
+                                                          PhoSimCatalogSN)
 from .twinklesVariabilityMixins import VariabilityTwinkles
 
 
 __all__ = ['TwinklesCatalogZPoint', 'TwinklesPhoSimCatalogSN']
 
+
+class TwinklesCatalogPoint(PhoSimCatalogPoint):
+
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'internalExtinctionModel',
+                      'galacticExtinctionModel', 'galacticAv', 'galacticRv']
+
+class TwinklesCatalogSersic2D(PhoSimCatalogSersic2D):
+
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'majorAxis', 'minorAxis', 'positionAngle', 'sindex',
+                      'internalExtinctionModel', 'internalAv', 'internalRv',
+                      'galacticExtinctionModel', 'galacticAv', 'galacticRv']
 
 class TwinklesCatalogZPoint(PhoSimCatalogZPoint, VariabilityTwinkles):
     """
@@ -15,6 +32,11 @@ class TwinklesCatalogZPoint(PhoSimCatalogZPoint, VariabilityTwinkles):
     AGN
     """
     catalog_type = 'twinkles_catalog_ZPOINT'
+
+    column_outputs = ['prefix', 'uniqueId', 'raPhoSim', 'decPhoSim', 'phoSimMagNorm', 'sedFilepath',
+                      'redshift', 'shear1', 'shear2', 'kappa', 'raOffset', 'decOffset',
+                      'spatialmodel', 'internalExtinctionModel',
+                      'galacticExtinctionModel', 'galacticAv', 'galacticRv']
 
 class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
     """
@@ -42,4 +64,3 @@ class TwinklesPhoSimCatalogSN(PhoSimCatalogSN):
                       'spatialmodel', 'internalExtinctionModel',
                       'galacticExtinctionModel', 'galacticAv', 'galacticRv']
     cannot_be_null = ['x0', 't0', 'z', 'shorterFileNames']
-

--- a/python/desc/twinkles/twinklesDBConnections.py
+++ b/python/desc/twinkles/twinklesDBConnections.py
@@ -7,7 +7,6 @@ __all__ = ["StarCacheDBObj"]
 
 class StarCacheDBObj(CatalogDBObject):
     tableid = 'star_cache_table'
-    database = os.path.join(getPackageDir('twinkles'), 'data', 'star_cache.db')
     host = None
     port = None
     driver = 'sqlite'
@@ -31,7 +30,6 @@ class StarCacheDBObj(CatalogDBObject):
 
 
 class SNCacheDBObj(SNDBObj, CatalogDBObject):
-    database = os.path.join(getPackageDir('twinkles'), 'data', 'sn_cache.db')
     host = None
     port = None
     tableid = 'sn_cache_table'

--- a/python/desc/twinkles/twinklesGalaxyCache.py
+++ b/python/desc/twinkles/twinklesGalaxyCache.py
@@ -21,8 +21,7 @@ _galaxy_cache_file_name = os.path.join(getPackageDir('twinkles'), 'data',
 _galaxy_cache_table_name = 'galaxy_cache'
 
 # the name of the sqlite database produced from the galaxy cache
-_galaxy_cache_db_name = os.path.join(getPackageDir('twinkles'), 'data',
-                                     'galaxy_cache.db')
+_galaxy_cache_db_name = 'galaxy_cache.db'
 
 # the dtype describing the contents of the galaxy cache
 _galaxy_cache_dtype = np.dtype([('galtileid', int),
@@ -48,10 +47,12 @@ class GalaxyTileObjDegrees(GalaxyTileObj):
         return results
 
 
-def create_galaxy_cache():
+def create_galaxy_cache(db_dir):
     """
     Create an sqlite .db file in data/ containing all of the galaxies
     in the Twinkles field of view.
+
+    db_dir is the directory in which we want to create the galaxy cache
     """
 
     obs = ObservationMetaData(pointingRA=53.0091385,
@@ -85,12 +86,14 @@ def create_galaxy_cache():
                                          line[21], line[22], line[23])).replace('nan', 'NULL').replace('None', 'NULL')
                                    + '\n')
 
+    full_db_name = os.path.join(db_dir, _galaxy_cache_db_name)
+
     if os.path.exists(_galaxy_cache_db_name):
-        os.unlink(_galaxy_cache_db_name)
+        raise RuntimeError("Trying to create %s, but it already exists" % full_db_name)
 
     dbo = fileDBObject(_galaxy_cache_file_name, driver='sqlite',
                        runtable=_galaxy_cache_table_name,
-                       database=_galaxy_cache_db_name,
+                       database=full_db_name,
                        dtype=_galaxy_cache_dtype,
                        delimiter=';',
                        idColKey='galtileid')
@@ -109,7 +112,6 @@ class GalaxyCacheBase(CatalogDBObject):
     idColKey = 'galtileid'
     raColName = 'ra'
     decColName = 'dec'
-    database = _galaxy_cache_db_name
     host = None
     port = None
     driver = 'sqlite'

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -90,11 +90,11 @@ class TwinklesSky(object):
         # Lists of component phosim Instance Catalogs and CatalogDBObjects
         # Stars
         self.compoundStarDBList = [StarCacheDBObj]
-        self.compoundStarICList = [TwinklesPhoSimCatalogPoint]
+        self.compoundStarICList = [TwinklesCatalogPoint]
 
         # Galaxies
         self.compoundGalDBList = [GalaxyCacheBulgeObj, GalaxyCacheDiskObj, GalaxyCacheAgnObj]
-        self.compoundGalICList = [TwinklesPhoSimCatalogSersic2D, TwinklesPhoSimCatalogSersic2D,
+        self.compoundGalICList = [TwinklesCatalogSersic2D, TwinklesCatalogSersic2D,
                                   TwinklesCatalogZPoint]
 
         if not os.path.exists(_galaxy_cache_db_name):
@@ -149,8 +149,8 @@ class TwinklesSky(object):
                              write_header=False)
 
         t_after_galCat = time.time()
-        snphosim = TwinklesPhoSimCatalogSN(db_obj=self.snObj,
-                                           obs_metadata=self.obs_metadata)
+        snphosim = TwinklesCatalogSN(db_obj=self.snObj,
+                                     obs_metadata=self.obs_metadata)
         ### Set properties
         snphosim.writeSedFile = True
         snphosim.suppressDimSN = True

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -12,14 +12,11 @@ import numpy as np
 import os
 from lsst.utils import getPackageDir
 from lsst.sims.catalogs.definitions import CompoundInstanceCatalog
-from lsst.sims.catUtils.exampleCatalogDefinitions import\
-    (PhoSimCatalogPoint,
-     PhoSimCatalogSersic2D,
-     DefaultPhoSimHeaderMap,
-     DefaultPhoSimInstanceCatalogCols)
 from .twinklesDBConnections import StarCacheDBObj, SNCacheDBObj
-from .twinklesCatalogDefs import TwinklesCatalogZPoint
-from .twinklesCatalogDefs import TwinklesPhoSimCatalogSN
+from lsst.sims.catUtils.exampleCatalogDefinitions import (DefaultPhoSimHeaderMap,
+                                                          DefaultPhoSimInstanceCatalogCols)
+from .twinklesCatalogDefs import (TwinklesCatalogZPoint, TwinklesCatalogPoint,
+                                  TwinklesCatalogSersic2D, TwinklesCatalogSN)
 from desc.twinkles import (GalaxyCacheDiskObj, GalaxyCacheBulgeObj,
                            GalaxyCacheAgnObj, GalaxyCacheSprinklerObj,
                            create_galaxy_cache,
@@ -93,11 +90,11 @@ class TwinklesSky(object):
         # Lists of component phosim Instance Catalogs and CatalogDBObjects
         # Stars
         self.compoundStarDBList = [StarCacheDBObj]
-        self.compoundStarICList = [PhoSimCatalogPoint]
+        self.compoundStarICList = [TwinklesPhoSimCatalogPoint]
 
         # Galaxies
         self.compoundGalDBList = [GalaxyCacheBulgeObj, GalaxyCacheDiskObj, GalaxyCacheAgnObj]
-        self.compoundGalICList = [PhoSimCatalogSersic2D, PhoSimCatalogSersic2D,
+        self.compoundGalICList = [TwinklesPhoSimCatalogSersic2D, TwinklesPhoSimCatalogSersic2D,
                                   TwinklesCatalogZPoint]
 
         if not os.path.exists(_galaxy_cache_db_name):

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -46,7 +46,8 @@ class TwinklesSky(object):
                  availableConnections=None,
                  sntable='TwinkSN_run3',
                  sn_sedfile_prefix='spectra_files/specFile_',
-                 db_config=None):
+                 db_config=None,
+                 cache_dir=None):
         """
         Parameters
         ----------
@@ -67,6 +68,8 @@ class TwinklesSky(object):
         sn_sedfile_prefix : string, optional, defaults to `spectra_files/specFile_'
             prefix for sed of the supernovae.
         db_config : the name of a file overriding the fatboy connection information
+        cache_dir : the directory containing the source data of astrophysical objects
+
         Attributes
         ----------
         snObj : CatalogDBObj for SN
@@ -74,6 +77,9 @@ class TwinklesSky(object):
 
         ..notes : 
         """
+        if cache_dir is None:
+            raise RuntimeError("Must specify cache_dir in TwinklesSky")
+
         # Observation MetaData
         self.obs_metadata = obs_metadata
 
@@ -87,6 +93,18 @@ class TwinklesSky(object):
 
         self.availableConnections = availableConnections
 
+        full_gal_name = os.path.join(cache_dir, _galaxy_cache_db_name)
+        full_star_name = os.path.join(cache_dir, 'star_cache.db')
+        full_sn_name = os.path.join(cache_dir, 'sn_cache.db')
+        if not os.path.exists(full_gal_name):
+            create_galaxy_cache(cache_dir)
+
+        StarCacheDBObj.database = full_star_name
+        GalaxyCacheBulgeObj.database = full_gal_name
+        GalaxyCacheDiskObj.database = full_gal_name
+        GalaxyCacheAgnObj.database = full_gal_name
+        SNCacheDBObj.database = full_sn_name
+
         # Lists of component phosim Instance Catalogs and CatalogDBObjects
         # Stars
         self.compoundStarDBList = [StarCacheDBObj]
@@ -96,9 +114,6 @@ class TwinklesSky(object):
         self.compoundGalDBList = [GalaxyCacheBulgeObj, GalaxyCacheDiskObj, GalaxyCacheAgnObj]
         self.compoundGalICList = [TwinklesCatalogSersic2D, TwinklesCatalogSersic2D,
                                   TwinklesCatalogZPoint]
-
-        if not os.path.exists(_galaxy_cache_db_name):
-            create_galaxy_cache()
 
         # SN 
         ## SN catalogDBObject

--- a/python/desc/twinkles/twinkles_sky.py
+++ b/python/desc/twinkles/twinkles_sky.py
@@ -93,17 +93,22 @@ class TwinklesSky(object):
 
         self.availableConnections = availableConnections
 
-        full_gal_name = os.path.join(cache_dir, _galaxy_cache_db_name)
-        full_star_name = os.path.join(cache_dir, 'star_cache.db')
-        full_sn_name = os.path.join(cache_dir, 'sn_cache.db')
-        if not os.path.exists(full_gal_name):
-            create_galaxy_cache(cache_dir)
+        # The databases of astrophysical objects
+        gal_db_name = os.path.join(cache_dir, _galaxy_cache_db_name)
+        star_db_name = os.path.join(cache_dir, 'star_cache.db')
+        sn_db_name = os.path.join(cache_dir, 'sn_cache.db')
+        if not os.path.exists(gal_db_name):
+            raise RuntimeError("Cannot find %s" % gal_db_name)
+        if not os.path.exists(star_db_name):
+            raise RuntimeError("Cannot find %s" % star_db_name)
+        if not os.path.exists(sn_db_name):
+            raise RuntimeError("Cannot find %s" % sn_db_name)
 
-        StarCacheDBObj.database = full_star_name
-        GalaxyCacheBulgeObj.database = full_gal_name
-        GalaxyCacheDiskObj.database = full_gal_name
-        GalaxyCacheAgnObj.database = full_gal_name
-        SNCacheDBObj.database = full_sn_name
+        StarCacheDBObj.database = star_db_name
+        GalaxyCacheBulgeObj.database = gal_db_name
+        GalaxyCacheDiskObj.database = gal_db_name
+        GalaxyCacheAgnObj.database = gal_db_name
+        SNCacheDBObj.database = sn_db_name
 
         # Lists of component phosim Instance Catalogs and CatalogDBObjects
         # Stars

--- a/utils/createCaches.py
+++ b/utils/createCaches.py
@@ -119,6 +119,6 @@ def create_sn_cache(db=None):
 
 if __name__ == "__main__":
 
-    create_galaxy_cache()
+    create_galaxy_cache(os.path.join(getPackageDir('twinkles'),'data')
     create_star_cache()
     create_sn_cache()


### PR DESCRIPTION
This should fix the order of extinction parameters in the PhoSim InstanceCatalogs (of course, we won't be able to test it until fatboy comes back on-line....)