### PR TITLE
Fixed bug reported by @TomGlazman, and added extra print statement

### DIFF
--- a/bin/get_twinkles_visits.py
+++ b/bin/get_twinkles_visits.py
@@ -49,7 +49,10 @@ if args.orderObsHistID:
     ops.Twinkles_3p2.obsHistID.to_csv(args.outfile, index=False, mode='a')
     with open(args.outfile, 'a') as output:
         output.write('# Begin Section Twinkles 3.3\n')
-    ops.Twinkles_3p2.obsHistID.to_csv(args.outfile, index=False, mode='a')
+    ops.Twinkles_3p3.obsHistID.to_csv(args.outfile, index=False, mode='a')
+    print("Left out {0} visits due to"
+          "the time limit of {1}".format(len(ops.obsHistIDsPredictedToTakeTooLong),
+                                         args.maxPredTime))
 else:
     obsHistIDs = get_twinkles_visits(args.opsimDB)
 


### PR DESCRIPTION
- Bug was due to `Twinkles.3p2` being printed twice in place of
  `Twinkles.3p3`
- Added a print statement on how many viits are left out due to
  maxPredTime
	modified:   get_twinkles_visits.py

Fixed the bug discussed in #347 
- Added the `RF_pickle.p` file to `Twinkles/data` which was missing as reported by @TomGlanzman too in the same thread.
