### PR TITLE
Twinkles 3p4 : the visits that should be part of Twinkles but were left

### DIFF
--- a/bin/get_twinkles_visits.py
+++ b/bin/get_twinkles_visits.py
@@ -53,6 +53,15 @@ if args.orderObsHistID:
     with open(args.outfile, 'a') as output:
         output.write('# Begin Section Twinkles 3.3\n')
     ops.Twinkles_3p3.obsHistID.to_csv(args.outfile, index=False, mode='a')
+
+    Obs_3p4a, Obs_3p4b = ops.Twinkles_3p4
+    with open(args.outfile, 'a') as output:
+        output.write('# Begin Section Twinkles 3.4 WFD\n')
+    Obs_3p4a['obsHistID'].to_csv(args.outfile, index=False, mode='a')
+    with open(args.outfile, 'a') as output:
+        output.write('# Begin Section Twinkles 3.4 DDF\n')
+    Obs_3p4b['obsHistID'].to_csv(args.outfile, index=False, mode='a')
+
     print("Left out {0} visits due to"
           "the time limit of {1}".format(len(ops.obsHistIDsPredictedToTakeTooLong),
                                          args.maxPredTime))

--- a/examples/notebooks/Example_OpSimOrdering.ipynb
+++ b/examples/notebooks/Example_OpSimOrdering.ipynb
@@ -730,7 +730,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -741,7 +741,7 @@
        "array([u'i', u'r', u'g'], dtype=object)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -753,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -762,7 +762,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAArgAAAH3CAYAAABQJiwLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3X9wG/d95/8XQMi2LCxAfpM4Pw5rtWlTCyzV3CVnN6Cb\nH73aZqT+SCOdKOXafivLtNVcr0a/Z9WX3rdlWsXXTsbyNJimc9WJZOvptDXpVudv2sSCZHvuO6mJ\nxlW+/fYrkHQnbtNoMUnsJkNil7Jsi8R+/1C5JkQRBAgsgF0+HzMaAvtZvPAhiA/15uKzn424rusK\nAAAACIlopzsAAAAAtBIFLgAAAEKFAhcAAAChQoELAACAUKHABQAAQKhQ4AIAACBUKHABAAAQKhS4\nAAAACBUKXAAAAIQKBS4AdKF9+/bpl3/5lzvdDQAIpFinOwAAWOsTn/iEkslkp7sBAIEUcV3X7XQn\nAAAAgFZhigIAAABChQJ3i3IcR/fee6927dql/fv368SJE7r77ru1f//+TncNgKQjR47oscce63Q3\nAKxy5MgRjY2NaXJyUnfffbcKhUKnu4R1MAd3i3rwwQd166236jOf+YzOnDmjU6dO6dlnn1U8Hu90\n1wAA6FqTk5OKRCJ6+OGHlclkOt0drIMjuFtUoVDQoUOHlEqlNDIyonK5rIWFhU53CwCArmbbtk6f\nPq277767011BDRS4W9TQ0JC++MUvynEcnTlzRslkUqlUqtPdAgCgq2UyGT7tDACmKGxhc3Nz+rEf\n+zGZpqnHH3+8090BAKDrmabZ6S6gDhS4W9Ts7KzOnTvX6W4AAAC0HAXuFjY1NSXTNJVMJmWapgzD\n6HSXAAAAmkaBu0WZpqlPf/rT3n3XdfWDP/iDyuVyzMUFukAkEul0FwBcg3EZHFzJbAuamprS5OSk\nHn/8cW+ifKlU0oMPPqjdu3frN3/zNzvcQzRjdHRUDz/8sPeztSxL+XxepmmqVCppeHjYO1pfqw1A\n/fL5vIaGhqq2FQoFzczMSJIuXLigY8eOefM3GZeAvxo6gnv33XfLsiwlk0mt1MVHjx7Vfffdx2AN\nkGQyqVKppAsXLmhgYECGYahcLstxHO3cubPT3UMTCoWC8vm8HnjgAa/AzWazOn36tKSrF/jIZrOa\nmJjYsA3AxvL5vMrlskZHR3X+/Hlv3DmOo5mZGY2MjHj7HTlyxDv3gXEJ+KuhAvfQoUP66Ec/qmQy\nKUk6efKk7rvvPkkM1iAZGhpSJBLRo48+qtnZWUUiEfX39+uBBx7QgQMHOt09bJLjOJLkjU9J3s93\nhWEYKhaLKpVKsm173TamqQD1WTlqu3rKlyQVi0U99thjXoE7ODgoy7I2HHuMS6A16i5wHcfRwYMH\nvb9OC4WCDh48KIn/RIPonnvu0T333NPpbqCFzpw5owMHDmj1rKNisaje3t6q/ZLJpCzLkmVZ67Yx\nNoHGXDvbL5PJeAd2pKtTFCKRiFKplKamphiXgM/qvtCDYRhVCxvPzs56g63Wf6K12gC0RqFQ0J49\ne9Zst217zTbDMOQ4Ts02AM1Lp9Pe7bGxMR0/flwS4xJoh01dyWxsbMw7eisxWIFOWhlL17uyTiKR\nWHMJZsdxZBhGzTYArTM1NaU9e/Z4U8AYl4D/NlXgfulLX6r6z9TPwcoiD0Bt09PTKpVKevLJJzU1\nNeWd1Dk3N6eBgYE1+5fLZZmmWbOtXoxP4Kr1lo8qFArq7e2tOr/B73EpMTaBhtfBLRQKawbywMCA\nJicnq7atDMhkMrluWz0ikYhs+7KWlyuNdrWmnp6oEontLc8m1//soOb65dqliUZHRzU0NORNIVr9\naYlt2zJNs662evgxPoP68w1Krp/ZQc1thesVlCtLhK2c7zA1NaW9e/eqv7/f13EpMTb9zPUzm9zq\n3GY0XODOzMysmVPr92BdXq5oaam1b06/s8n1PztouX5zHEeTk5OKRCI6deqU7r//fqVSKeVyOY2P\njyuVSqlYLCqXy3mPqdVWr6D9HMj1Pztouc1YWes2Eono5MmTGhwcVCaTkWVZ2r9/v3dAyHVdJZNJ\nDQ8PS6o99loxLqXg/RyClutnNrnNa/hCD1NTU5qZmVlzMYC5uTlNT097A/LgwYNeEVurbSPT09P/\n8pdB8x+3vOMd79Ctt15d5zUWi6qvb4fm5y+19IdCrv/ZQc0Nq6D9HLZ6rp/ZQc0Nq6D9HIKS62c2\nudW5TWU0+oCVvz6vlU6nvTNGr/3ItFbbRu68885Gu7iuX/iF/6Tjx3+rZXkAAADoPps6yQwAAADo\nVg0fwe2Un//5+7R9e+MTjr/97W/qqadOb7wjAAAAQiEwBe5/+S//p9761rc2/LgXXvgKBS4AAMAW\nwhQFAAAAhAoFLgAAAEKFAhcAAAChQoELAACAUKHABQAAQKhQ4AIAACBUKHABAAAQKhS4AAAACBUK\nXAAAAIQKBS4AAABChQIXAAAAoUKBCwAAgFChwAUAAECoUOACAAAgVChwAQAAECoUuAAAAAgVClwA\nAACECgUuAAAAQoUCFwAAAKFCgQsAAIBQocAFAABAqFDgAgAAIFQocAEAABAqsU53AEBwfepTn9Jr\nr11RpeJKkkZGjuqd73xXh3sFANjqKHABbNpnP/vZqvs//dP7KHABAB3HFAUAAACECgUugKZ8+MMf\n6XQXAACoQoELoClve9stne4CAABVKHABAAAQKhS4AAAACBUKXAAAAIQKBS4AAABChQIXAAAAoUKB\nCwAAgFChwAUAAECoUOACAAAgVChwAQAAECoUuAAAAAiVWKc7AKB5hUJBtm2rXC7r+eef19GjR9Xf\n3y9JGh0d1dTUlCKRiPr7+/XII48onU5LkizLUj6fl2maKpVKGh4elmEYnfxWAABoGgUuEAL33nuv\nnnrqKe3atUuSlM1mde7cOUnSzp07df78eUlSPB6velw2m9Xp06clSY7jKJvNamJioo09BwCg9Zii\nAITAM8884xW3kpRIJLzbrusqHo+vKW5nZ2cViUS8+4ZhqFgsqlQq+d9hAAB8RIELhEAqlfJuX7x4\nUblczru/sLCgs2fPqlAo6MSJE7IsS5JULBbV29tblZNMJr12AACCiikKQEhYlqXJyUnNzc3Jtm1v\n+6FDh7wCOJlMetMSVu+zwjAMOY7T0POuPgrc0xNVLNbc3809PdGqr61Crv/ZQc0No5tuuum62//j\nf/wl/eqvjra5N0D7UeACIWGapo4dO6axsTEdPnxYzz33nOLxeNXRXdM0NTc3p8XFRSUSCS0sLFRl\nOI7T8Elm27b1eLcTie3q69vR3DeyKssP5PqfHbTcMHr99devu31pabnNPQE6gwIXCLiVI7fHjh2T\nJA0NDenEiRO6cOGCksmkDh8+rBdeeEGSqorXgYEBTU5OVmWVy2WZptnQ81+58uZ/mLZ9WfPzlzb7\nrUi6elQtkdgu276s5eVKU1nktjc7qLlh9Z73/IBuvPEmLS46+qd/+nqnuwO0FQUuEHClUkmFQsG7\nb1mWksmkdu/eLdd1dfToUa/tzJkzGhwcVDweV39/f9V0BNu2ZZpm1RHferiu691eXq5oaak1BUgr\ns8htb3bQcsPqT/5kSjt3vlvT03+ln/7pvZ3uDtBWDRe4+Xxetm17Z2kPDQ1Jqr2eJmttAv7JZDI6\ndOiQnnzySbmuq+npaT3++OPeqgn9/f0aHx+XYRiyLKvqBLRcLqfx8XGlUikVi8WqNgAAgqqhAndq\nakqO4+i+++6TZVm67777vAK31nqarLUJ+OvAgQPe7eHh4aq2TCajTCZz3cel02nvog8rYxkAgKBr\nqMA9ceKEN5fPNE2vaK21nqZt2+u2NfpRKAAAALCRugvclSJ2Za7f9PS0hoeHFY/Ha66naVnWum0U\nuAAAAGi1ugvcYrFYdRLKwMCA9u3bp3PnztVcT7NVa23GYpFNra/Z0/Pm0eNo9M2MoK7XGJRcP7OD\nmgsAANqj7gLXNE0lEgnvqOvKCStzc3M119Ns1Vqbvb07NrW+5uolYG66aduajKCt1xi0XD+zg5YL\nAADao+4CN5VKXfdorFR7Pc1kMtmStTYXFi4pFru5ocdIV9flXPGFL/yFvv71b0i6evWlbdt6dOXK\nctUyR/U4eXJcsdj1X7qgrgPJWpustQkAQFg0dAS3v7/fOznMsizdeuut3hnYtdbTbMVam0tL7qbW\nP1xefrN4femlr+mll77WcMa1fvd3T0qq/bFz0NaBZK1N/3MBAEB7NLSKQi6X0+TkpEzT1MzMTNVS\nX7XW02StTQAAALRLQwVuKpXSQw89dN22WutpdnKtzR/6offqq18trtkei0WVTN6scvnVuo7WjYz8\n7/rbv/1//OgiACDg8vn8mv/fNnsBJC6OBDQv9Jfqvemmm2Sat67ZHotF1de3Q/Pzl+oqcG+88SY/\nugcACLB8Pq9yuazR0VGdP3/eu4KgtPkLIHFxJKB5rF8EAMAmDQ0NaXh4uOqCRlLtCyBttg1A/UJ/\nBBcAAL9duxrPZi+AxMWRgNbgCC4AAC222QsgteriSMBWxxFcAABabLMXQGrVxZGkq2twx2LRda/o\nuZm81V9bJWi5fmaTW53bDApcAACadO0c3M1eAKlVF0eSpHj8JvX17ZBh1L6iZ6OCdhVJrtQZ3Nxm\nUOACANCka+fg9vf3b/oCSK24OJIkLS6+pvn5S3KcN6/o+dprVzQ/f6nhLCm4V5HkSp3BzW0GBS4A\nAJtUKBQ0MzOjSCSikydPanBwUJlMRtLmL4DUqosjrVyVcfUVPSuVzV0V9Hq5rRa0XD+zyW0eBS4A\nAJuUyWSUyWQ0MjKypm2zF0Dq5MWRgLBgFQUAAACECgUuAAAAQoUCFwAAAKFCgQsAAIBQocAFAABA\nqFDgAgAAIFQocAEAABAqFLgAAAAIFQpcAAAAhAoFLoCW+bEf+6BuuSWhW25J6C/+4qlOdwcAsEVR\n4AIAACBUYp3uAIBg27lzp97//tslSS+//G2VSlaHewQA2Oo4ggugKb/0S7+sp59+Vk8//axGRn6h\n090BAIACFwAAAOFCgQsAAIBQocAFAABAqFDgAgAAIFQocAEAABAqFLgAAAAIFQpcAAAAhAoFLgAA\nAEKFAhcAAAChQoELAACAUKHABQAAQKhQ4AIAACBUYp3uAIDmFQoF2batcrms559/XkePHlV/f78k\nybIs5fN5maapUqmk4eFhGYaxYRsAAEFFgQuEwL333qunnnpKu3btkiRls1mdO3fOu3369GlJkuM4\nymazmpiY2LANQPj86Z/+kZ577pmqbb29vfqf//OLHeoR4A8KXCAEnnnmGaVSKe9+IpGQJM3OzioS\niXjbDcNQsVhUqVSSbdvrtq3OAhAe3/nOd/Sd73ynattb3vKWDvUG8A8FLhACqwvSixcvKpfLSZKK\nxaJ6e3ur9k0mk7IsS5ZlrdtGgQuERzQa1U033bRm+2uvvdaB3gDtQYELhIRlWZqcnNTc3Jxs25Yk\n7+tqhmHIcZyabY2IRqOKxaL/cjuyanvE296Inp5o1ddWIdf/7KDmht0HPjCoixdfWbP9jjveq3/6\np693oEeA/yhwgZAwTVPHjh3T2NiYDh8+rOeee06JREILCwtV+zmOI8MwarY1IpHYrmRyhyTp5ptv\n8LbH4zepr2/HJr+bq7l+INf/7KDlAggfClwg4FaO3B47dkySNDQ0pBMnTujChQsaGBjQE088UbV/\nuVyWaZpKJpOanJy8blsjbPuyKpWrv0peffUNb/vi4muan7/U8PfT0xNVIrFdtn1Zy8uVhh9Pbuey\ng5oLIHwocIGAK5VKKhQK3n3LspRMJrV7927F43EtLi56bbZtyzRNb47t6ukI17bVq1KpaGmp8i+3\nXW/73/3d32n79pslSe9+9/fre77nexvKXV5+M7eVyPU/O2i5AMKHAhcIuEwmo0OHDunJJ5+U67qa\nnp7W448/rng8LknK5XIaHx9XKpVSsVj0TkDbqK1Zn/vcCe/2r//6cf3SL/1yy7IBAKiFAhcIgQMH\nDni3h4eHq9rS6bTS6bSkq9MX6m0DACCoKHABtMy//bd36Fd+5VclSV/72t/rqadOd7hHAICtiAIX\nQMvccccP6447fliS9MUv/gUFLgCgI7bGIoAAAADYMihwAQAAECoUuAAAAAiVhubgjo6OampqSpFI\nRP39/XrkkUe8M7Aty1I+n5dpmiqVShoeHvauiFSrDQAAAGilhgrcnTt36vz585LkrbG5IpvN6vTp\nqyeUOI6jbDariYmJDdsAAACAVmqowHVdd01hK0mzs7OKRCLefcMwVCwWVSqVZNv2um2NXjEJAAAA\n2EhDBe7CwoLOnj0rwzD0/PPP6+DBgzJNU8ViUb29vVX7JpNJWZYly7LWbaPABQAAQKs1VOAeOnTI\nK0qTyaQ39cC27TX7GoYhx3FqtjXU0VhEsVjrzonr6YlWfd3IqoPQisWi6/al0dx6BS3Xz+yg5gIA\ngPZoqMBdfcTVNE3Nzc1pcXFRiURCCwsLVfs6jiPDMGq2NaK3d4f6+nY09Jh6JBLb69ovFuvxbvf1\n7dANN9zQktxGBS3Xz+yg5QIAgPaou8CdnZ3V4cOH9cILL0hSVYE6MDCgycnJqv3L5bJM01QymVy3\nrRELC5cUi93c0GNq6emJKpHYLtu+rOXlyob7Ly0te7fn5y/phhuutCTXr/52OtfP7KDmAgCA9qi7\nwDVNU0ePHvXunzlzRoODg4rH4+rv76+acmDbtkzT9I741mqr19KSq6Wl1hZgkrS8XKkr13VX96Wi\naLT2Y+rNbVTQcv3MDlouAABoj7oLXMMw1N/fr/HxcRmGIcuylMvlvPZcLqfx8XGlUikVi8W62wAA\nAIBWamgObiaTUSaTuW5bOp32LvowNDRUd1sQFYv/n7Zt23bdtno/5r7llrfr7W9/h19dBAAA2LIa\nKnBx1Uc/+u+aznj44f+qY8c+1YLeAAAAYDXWLwIAAECocAS3Tnv2/IR27UpvuF80GtGNN27T669f\nUaXiVrWVSpaeeeasX10EAACAKHDr9slP/qe69ovFourr26H5+UtrzsR/9tmzFLgAAAA+Y4oCAAAA\nQoUjuAB896UvfUHf+MY/SZI+8IGM/v2/P9jZDgEAQo0CF4DvvvrV8/rqV89LklzXpcAFAPiKKQoA\nAAAIFY7gAvDFBz/4IT333POSpH/8x5c0MvLzHe4RAGCroMAF4ItEIqmBgd2SpEgk0uHeAJ1hWZYK\nhYJ3e8+ePerv7/fu5/N5maapUqmk4eFhGYaxYRuAjVHgAgDgk8nJSR07dsy7Pzo6quPHj0uSstms\nTp8+LUlyHEfZbFYTExMbtgHYGHNwAQDwST6fl2VZ3v2VTzNmZ2erPtkwDEPFYlGlUqlmG4D6cAQX\nAACfHDx4UHfffbdGRkZ066236v7775ckFYtF9fb2Vu2bTCZlWZYsy1q3LZVKta3vQJBR4AIA4JOD\nBw+qXC5renpaZ8+e1cDAgCTJtu01+xqGIcdxarY1oqcnqlhs/Q9qVx8lrrXf6rzVX1slaLl+ZpNb\nndsMClwAAHzgOI4effRRHT9+XA899JCmpqZ077336tlnn1UikdDCwsKa/Q3DqNnWiHj8JvX17Vi3\nPRq9WuBGIpGa+10rkdjeUD/CmutnNrnNo8AFAMAH09PT+pEf+RHv/vDwsCzL0oULFzQwMKAnnnii\nav9yuSzTNJVMJjU5OXndtkYsLr6m+flL67ZXKq6kqxdfqbXfip6eqBKJ7bLty1perjTUlzDl+plN\nbnVuMyhwAQDwgWmaevrpp3XPPfdUbd+9e7fi8bgWFxe9bbZtyzRNb47t6ukI17bVa3m5oqWl9YsO\n13W927X2azR3s4KW62c2uc2jwAUAwAf9/f0qlUoaHx/35tDu3btX8XhckpTL5TQ+Pq5UKqVisahc\nLuc9tlYbgI1R4AIA4JNrj96ulk6nlU6nJUlDQ0N1twHYGOvgAgAAIFQocAEAABAqFLgAAAAIFQpc\nAAAAhAoFLgAAAEKFAhcAAAChQoELAACAUKHABQAAQKhwoQcgBAqFgmZmZiRJFy5c0LFjx7zr1o+O\njmpqakqRSET9/f165JFHvAXkLctSPp+XaZoqlUoaHh6WYRgd+z4AAGgFClwg4BzH0czMjEZGRiRJ\n+XxeR44c0blz5yRJO3fu1Pnz5yXJu0Toimw2q9OnT3s52WxWExMTbew9AACtxxQFIOCKxaIee+wx\n7/7g4KAsy1KpVJIkua6reDy+pridnZ1VJBLx7huGoWKx6D0OAICgosAFAi6TyXhHYaWrUxQikYhS\nqZQkaWFhQWfPnlWhUNCJEydkWZakq4Vxb29vVVYymfTaAQAIKqYoACGwMqdWksbGxnT8+HHv/qFD\nh7xiN5lMetMSbNtek2MYhhzHaei5o9GoYrHafyuvbo9GVXP/np5o1ddWIdf/7KDmAggfClwgRKam\nprRnzx4dOHDA27ZS3EqSaZqam5vT4uKiEomEFhYWqh7vOE7DJ5klEtuVTO7YcJ8VN964TX19tfe/\n9jGtRK7/2UHLBRA+FLhASBQKBfX29uqee+7xts3Ozurw4cN64YUXJKmqeB0YGNDk5GRVRrlc9lZf\nqJdtX1alUvtXiW1f9m6//voVzc9fWnffnp6oEontsu3LWl6uNNSXWsj1PzuouQDChwIXCIGVJcJW\nitupqSnt3btXpmnq6NGj3n5nzpzR4OCg4vG4+vv7q6Yj2LYt0zSrjvjWo1KpaGmpdtGxur1S0Yb7\nS9Ly8sa5m0Gu/9lBywUQPhS4QMBZlqX9+/d7KyK4rqtkMqnh4WFJUn9/v8bHx2UYhizLUi6X8x6b\ny+U0Pj6uVCqlYrFY1QYAQFBR4AIBZ5qmXnzxxXXbM5mMMpnMddvS6bR3gtrQ0JAv/QMAoN04hRQA\nAAChQoELAACAUKHABQAAQKhQ4AIAACBUKHABAAAQKhS4AAAACBUKXAAAAIQKBS4AAABChQIXAAAA\noUKBCwAAgFChwAUAAECobLrAHR0d1eLionffsiyNjY0pn89rfHxcjuPU1QYAAAC0UmwzDyoUCsrn\n83rggQcUj8clSdlsVqdPn5YkOY6jbDariYmJDdsAbC0vv/wtPf/8lyVJyWSvBgZ2d7hHAICwabjA\nXTn6mkwmvW2zs7OKRCLefcMwVCwWVSqVZNv2um2pVKqZvgMIoLNnz+js2TOSpA996Ef1Z3/2f3W4\nRwCAsGl4isKZM2eUyWTkuq63rVgsqre3t2q/ZDIpy7JqtgEAAACt1tAR3EKhoD179qzZbtv2mm2G\nYchxnJptALaGt771rXrwwf8sSXrjjTf0+7//+Q73CAAQZnUXuCsF6cqc29USiYQWFhbW7G8YRs22\nhjoaiygWa92iDz090aqv7ciNRqOrbjf2/XSiv92aHdTcreztb3+Hfu3XfkOStLi4SIELAPBV3QXu\n9PS0bNvWk08+Kdd1ZVmW8vm8BgcHNTAwoMnJyar9y+WyTNNUMplct60Rvb071Ne3o6HH1COR2N7y\nzPVyDeMm7/b27Tds6vtpZ3+7PTtouQAAoD3qLnCHhoaq7o+OjmpoaMg7UWz1lAPbtmWaZl1t9VpY\nuKRY7OaGHlNLT09UicR22fZlLS9X2pLrOK95ty9ffkPz85e6ur/dmh3UXAAA0B6bWkVhcnJSkUhE\np06d0v33369UKqVcLqfx8XGlUikVi0XlcjnvMbXa6rW05GppqbUFmCQtL1fallupVFbd3tz3087+\ndnt20HIBAEB7NFzgGoahkZERjYyMVG1Pp9NKp9OS1h7trdUGAAAAtBJnvwAAACBUKHABAAAQKhS4\nAAAACBUKXAAAAIQKBS4AAABChQIXAAAAoUKBCwAAgFChwAUAAECoUOACAAAgVChwAQAAECoUuAAA\nAAgVClwAAACESqzTHQAAAJ3z3e9+V6b5tjXbJyb+SHff/dEO9AhoHgUuAABb3Ouvv75mW6XidqAn\nQGtQ4AIAsAXddtsuxeNG1bZXXnlZr7zycod6BLQOBS4AAFvQH/3R5Jptn/vcCf3Wbx3vQG+A1uIk\nMwAAAIQKBS4AAABChQIXAAAAoUKBCwAAgFDhJDMgBAqFgmZmZiRJFy5c0LFjx2SapiTJsizl83mZ\npqlSqaTh4WEZhrFhG4DWyOfzsm1biURCkjQ0NCSJsQn4iQIXCDjHcTQzM6ORkRFJV/8zPXLkiM6d\nOydJymazOn36tLdvNpvVxMTEhm0Amjc1NSXHcXTffffJsizdd999XoHL2AT8wxQFIOCKxaIee+wx\n7/7g4KAsy1KpVNLs7KwikYjXZhiGisXihm0AWuPEiRO67777JEmmaXpFK2MT8BcFLhBwmUzG+09T\nujpFIRKJKJVKqVgsqre3t2r/ZDIpy7JqtgFo3kqhWigUVCgU9Nhjj2l+fl6SGJuAz5iiAIRAOp32\nbo+Njen48asLtdu2vWZfwzDkOE7NtkZEo1HFYvX/rbx630hEax7b0xOt+toq5PqfHdRcvxSLRdm2\nLdM0lUqlNDAwoH379uncuXNtGZs9PY2NTUmKRt88ctzTE6l6fFB/voyh4OY2gwIXCJGpqSnt2bNH\nBw4ckCQlEgktLCxU7eM4jgzDqNnWiERiu5LJHXXvv22bu+p2j/r6rv/YRGJ7Q/2oF7n+Zwct1y+m\naSqRSCiVSkm6WqRalqW5ubm2jM14/KZ1x9d6tm+/YcPHB+3nyxgKbm4zKHCBkCgUCurt7dU999zj\nbRsYGNDkZPXlOMvlskzTVDKZXLetEbZ9WZVK/b9KFhcvebevXFnW/PylqvaenqgSie2y7ctaXq40\n1JdayPU/O6i5fkmlUtc9Giu1Z2wuLr62Znxt5PLlN9Z9fFB/voyh4OY2gwIXCIGVJcJWitupqSnt\n3btX/f39VR9rrv64VFLNtnpVKhUtLdX/i231vq6rdR+7vNxYbr3I9T87aLl+MU1T/f39KpVKSqVS\nsixLt956qzelyO+xuZnXq1J58xOW5WX3uo8P2s+XMRTc3GZQ4AIBZ1mW9u/f75117bquksmkhoeH\nJUm5XE4msMCNAAAgAElEQVTj4+PeSWe5XM57bK02AM3L5XKanJyUaZqamZmpWuqLsQn4hwIXCDjT\nNPXiiy+u255Op70jRivrb9bTBqB5qVRKDz300HXbGJuAf1gmDAAAAKFCgQsAAIBQocAFAABAqFDg\nAgAAIFQocAEAABAqFLgAAAAIFQpcAAAAhAoFLgAAAEKFAhcAAAChQoELAACAUKHABQAAQKhQ4AIA\nACBUKHABAAAQKhS4AAAACBUKXAAAAIQKBS4AAABChQIXAAAAoUKBCwAAgFCJdboDAACg+zzxxB/r\nhRf+2rsfjUb0vve9Vz/5k/s72CugPhS4AABgjS9+8Qtrtn3sYx+jwEUgNFTgFgoF2batcrms559/\nXkePHlV/f78kybIs5fN5maapUqmk4eFhGYaxYdtW9c///IpmZ2fq3j8WiyiRuFm2/aqWllxJUiQS\nUTrd71cXAQAAAqmhAvfee+/VU089pV27dkmSstmszp07590+ffq0JMlxHGWzWU1MTGzYtlX9wR+M\n6Q/+YKypjO3bt+sb33i5RT0CAGx1+/cP6447PlC1bX5+Xvfe+zMd6hGwOQ0VuM8884xSqZR3P5FI\nSJJmZ2cViUS87YZhqFgsqlQqybbtddtWZwEAgM4yzVtlmrdWbXvllVc61Btg8xoqcFcXpBcvXlQu\nl5MkFYtF9fb2Vu2bTCZlWZYsy1q3basVuO96V0o/93OHN/XYSES68cZtev31K/rCF57SwsJCazsH\ndMDLL39LTzzxx5KkHTt26Cd/8qc73CMAQBg0fJKZZVmanJzU3NycbNuWJO/raoZhyHGcmm0NdTQW\nUSzWulXNenqiVV/bkbt794Byuc9vOjeR2C7bvqyvfvW8V+A2+5r49Tr4mR3UXKz193//oh588JOS\npFtv/R4KXABASzRc4JqmqWPHjmlsbEyHDx/Wc889p0QiseaIouM4MgyjZlsjent3qK9vR6Pd3VAi\nsb3lmX7nri6YWvWa+NVfP7ODlgsAANqj7gJ35cjtsWPHJElDQ0M6ceKELly4oIGBAT3xxBNV+5fL\nZZmmqWQyqcnJyeu2NWJh4ZJisZsbekwtq4+ILi9XAps7P3/Jl9xWCMtr3KpcXHXjjTfq0Uc/593/\njd/4NV26tNjBHgEAwqbuArdUKqlQKHj3LctSMpnU7t27FY/Htbj45n9Qtm3LNE1vju3q6QjXttVr\nacnV0lJrCzBJWl6uBC7Xdd+836rn8Ku/fmYHLRdXbdu2TT//80e8+5/97H+jwAUAtFTdBW4mk9Gh\nQ4f05JNPynVdTU9P6/HHH1c8Hpck5XI5jY+PK5VKqVgseiegbdQGAAAAtFJDc3APHDjg3R4eHq5q\nS6fTSqfTkq5OX6i3DQAAAGglTu8GAABAqFDgAgAAIFQocAEAABAqFLgAAAAIFQpcAAAAhAoFLgAA\nAEKFAhcAAAChQoELAACAUKHABQAAQKhQ4AIAACBUKHABAAAQKhS4QEjk8/k120ZHR7Vr1y6l02nt\n379fc3NzXptlWRobG1M+n9f4+Lgcx2lndwEA8E2s0x0A0Jx8Pq9yuazR0VGdP39e8Xjca9u5c6fO\nnz8vSVXbJSmbzer06dOSJMdxlM1mNTEx0b6OAwDgE47gAgE3NDSk4eFhRSKRNW2u6yoej68pbmdn\nZ6v2NwxDxWJRpVLJ9/4CAOA3ClwgJFzXXbNtYWFBZ8+eVaFQ0IkTJ2RZliSpWCyqt7e3at9kMum1\nAwAQZExRAELs0KFDSqVSkq4WsCvTEmzbXrOvYRjMwwUAhAIFLhBiK8WtJJmmqbm5OS0uLiqRSGhh\nYaFqX8dxZBhGw88RjUYVi23+w6CVmRKRiBSLRdXTczVr5WurkOt/dlBzAYQPBS4QEtfOwZ2dndXh\nw4f1wgsvSFJV8TowMKDJycmq/cvlskzTbPh5E4ntSiZ3bKLHV630OxqNqK/vzZxEYvumM2sh1//s\noOUCCB8KXCAkrp2Da5qmjh496t0/c+aMBgcHFY/H1d/fXzUdwbZtmaZZdcS3XrZ9WZXK5n+VrPS7\nUnE1P39JPT1RJRLbZduXtbxc2XTutcj1PzuouQDChwIXCLhCoaCZmRlFIhGdPHlSg4ODymQyMgxD\n/f39Gh8fl2EYsixLuVzOe1wul9P4+LhSqZSKxWJVWyMqlYqWljZfdKzU5a6rqpzl5eZy10Ou/9lB\nywUQPhS4QMBlMhllMhmNjIys23Y96XRa6XRa0tWlxgAACAtm2AMAACBUKHABAAAQKhS4AAAACBUK\nXAAAAIQKBS4AAABChQIXAAAAoUKBCwAAgFBhHdwAu3Llin73dz/XVEZPT0Q//uMf1fd9X7pFvQIA\nXM/o6KgefvhhxeNxSZJlWcrn8zJNU6VSScPDw94ltWu1AdgYBW6ALS0t6TOfGW06p7fXoMAFAB8V\nCgXl83k98MADXoGbzWZ1+vRpSZLjOMpms5qYmNiwDcDGmKIAAICPHMeRJCWTSW/b7OysIpGId98w\nDBWLRZVKpZptAOrDEdwAOn78t7xfmJv11389rZMnf69FPQIArOfMmTM6cOCAXNf1thWLRfX29lbt\nl0wmZVmWLMtaty2VSrWlz0DQUeAG0Ic+9JGmM9544/XmOwIAqKlQKGjPnj1rttu2vWabYRhyHKdm\nG4D6UOACAOCDlYJ0Zc7taolEQgsLC2v2NwyjZlsjenqiisWan4kYi0Wq7vf0tHZ240peUHL9zCa3\nOrcZFLgAAPhgenpatm3rySeflOu63soIg4ODGhgY0OTkZNX+5XJZpmkqmUyu29aIePwm9fXtaPr7\neOON6oxEYnvTmdcTtFw/s8ltHgUuAAA+GBoaqro/OjqqoaEhbx7t6ikHtm3LNM262uq1uPia5ucv\nbbb7noWF6gzbvqzl5UrTuSt6eqJKJLYHJtfPbHKrc5tBgQsAgI8cx9Hk5KQikYhOnTql+++/X6lU\nSrlcTuPj40qlUioWi8rlct5jarXVa3m5oqWl5ouOpSW36n6rcq8VtFw/s8ltHgUuAAA+MgxDIyMj\nGhkZqdqeTqeVTl9dg/zao7212gBsjAIXAADU5Stf+Yp+9mcPqVKpPqr7e793UoaR6FCvgLUocAEA\nQF2+/e1v60tf+ss1269cudKB3gDr40pmAAAACBWO4AIAgHW95S1vUbH4kmKxiHp7d2hh4ZKWllx9\n8pMj+vKX/1enuwdcFwUuAABYV09Pj2655RbFYlH19e3QDTdc0tJSRTfeeEOnuwasiykKAAAACBUK\nXAAAAIQKBS4AAABChQIXAAAAoUKBCwAAgFChwAUAAECoNLRMWKFQ0MzMjCTpwoULOnbsmEzTlCRZ\nlqV8Pi/TNFUqlTQ8PCzDMDZsAwAAAFqp7gLXcRzNzMxoZGREkpTP53XkyBGdO3dOkpTNZnX69Glv\n32w2q4mJiQ3bAAAAgFaqe4pCsVjUY4895t0fHByUZVkqlUqanZ1VJBLx2gzDULFY3LANAAAAaLW6\nj+BmMhnvKKx0dYpCJBJRKpXS1NSUent7q/ZPJpOyLEuWZa3blkql6u9oLKJYrHVThnt6olVft1pu\nNBqput/q/q7O7PbXol25AACgPRqag5tOp73bY2NjOn78uCTJtu01+xqGIcdxarY1ord3h/r6djT0\nmHokEttbnhmE3Hj8Jl9yr6fbX4t25QIAgPZoqMBdMTU1pT179ujAgQOSpEQioYWFhap9HMeRYRg1\n2xqxsHBJsdjNm+nudfX0RJVIbJdtX9bycmXL5S4uvlZ1v9X9lYLzWrQrFwAAtEfDBW6hUFBvb6/u\nueceb9vAwIAmJyer9iuXyzJNU8lkct22RiwtuVpaam0BJknLy5UtmVupuL7kXk+3vxbtygUAAO3R\n0OTAlSXCVorbqakpLS4uqr+/v2rKgW3bMk1TqVSqZhsAAADQanUfwbUsS/v37/dWRHBdV8lkUsPD\nw5KkXC6n8fFxpVIpFYtF5XI577G12gAAAIBWqrvANU1TL7744rrt6XTaOwltaGio7jYAAACglVi/\nCAAAAKFCgQsAAIBQocAFAABAqGxqHVwA3Sefz6+Z425ZlvL5vEzTVKlU0vDwsLcGda02AACCjAIX\nKpfL+ta3vtXUxQ0ikaje/va3t7BXqFc+n1e5XNbo6KjOnz+veDzutWWzWe8S247jKJvNamJiYsM2\nAACCjAIX+vSnP61Pf/rTTWXccsvbVSx+rUU9QiNWjtpe+zOcnZ31lvWTrl4iu1gsqlQqybbtddtY\noxoAEHTMwQVCwnWrr05XLBbV29tbtS2ZTMqyrJptAAAEHUdwt6h3vvNf6cd//KcUiUg33BDTG28s\n6Zr6qC7PPXdOly9fbn0H0TTbttdsMwxDjuPUbAMAIOgocLeoD3wgow98IKNYLKq+vh2an7+kpaXG\n5+C+//0DsqyLPvQQzUokElpYWKja5jiODMOo2daoaDSqWGzzHwatzJSIRKRYLKqenqtZK19bhVz/\ns4OaCyB8KHCBkFg9p1aSBgYGNDk5WbWtXC7LNE0lk8l12xqVSGxXMrmj8Q7/i5V+R6MR9fW9mZNI\nbN90Zi3k+p8dtFwA4UOBC4TEtXNw+/v7q6Yc2LYt0zS9k8hqtTXCti+rUtn8r5KVflcqrubnL6mn\nJ6pEYrts+3JTK3tci1z/s4OaCyB8KHCBgCsUCpqZmVEkEtHJkyc1ODioTCYjScrlchofH1cqlVKx\nWFQul/MeV6utEZVKZVPTW1as1OWuq6qc5eXmctdDrv/ZQcsFED4UuEDAZTIZZTIZjYyMrGlLp9NK\np9OStOYiELXaAAAIMmbYAwAAIFQocAEAQFN+6Iduk2m+rerff//vn+90t7CFMUUBAAA05Y033liz\nbXl5uQM9Aa6iwAUAAA3bufN7NDDwQ1XbbLusixe/0aEeAW+iwAUAAA377d8+sWbbX/7lF3TkyM92\noDdANQpcAF3hm98saXDw/YpErl4drVD4aqe7BAAIKApcAF1haWlJL730tU53AwAQAhS4ADoqkUjo\nypUrkiTHsVWpsJA/AKA5LBMGoKP++q//Vl/72kV97WsX9W/+zfs73R0AQAhQ4AIAACBUKHABAAAQ\nKhS4AAAACBUKXAAAAIQKqyigJf75n1/Re9+7a832aDSiSsWtO+czn/lt/dRPfbyVXQMAAFsMBS5a\nwnVdfetb32w659VXX21BbwAAwFZGgYum3HLLLVpaWlq3vZ4juJcuXZJtl1vdNQAAsEVR4KIpTz/9\n3LptsVhUfX07ND9/SUtL6y/e/4d/OK6HH/4//OgeAADYgjjJDAAAAKFCgQsAAIBQocAFAABAqFDg\nAgAAIFQocAEAABAqFLgAAAAIFQpcAAAAhAoFLgAAAEKFAhcAAAChwpXM0FU+9amH9OlP/9cN9ooo\nEpFcV5LWXgb43e/+vppXWAOAdikUCpqZmZEkXbhwQceOHZNpmpIky7KUz+dlmqZKpZKGh4dlGMaG\nbQA2RoGLrvLqq6/q1VdfbSqjXC63qDcAsHmO42hmZkYjIyOSpHw+ryNHjujcuXOSpGw2q9OnT3v7\nZrNZTUxMbNgGYGMUuOi4RCKhd7/7++rePxKJKBqNqFJx5bpvHsH9+tf/seo+gu3ixW9oaakiSXrn\nO9+lbdu2dbhHQGOKxaIee+wxr8AdHByUZVkqlUqybVuRSMTb1zAMFYvFDdtSqVTbvw8giChw0XH7\n9h3Qvn0H6t4/Fouqr2+H5ucveQWQJL3nPbeqXF7wo4vogH/9r3/Qu/2Vr/y/+t7vfXcHewM0LpPJ\neEdhpatTFCKRiFKplKamptTb21u1fzKZlGVZsixr3TYKXKA+FLgAAPgknU57t8fGxnT8+HFJkm3b\na/Y1DEOO49Rsa0RPT1SxWOvOJe/piVZ9vf4+bx55jkYjdT1/Pbmb4Veun9nkVuc2gwIXQNf48Id/\nVDt37tQNN8T0V3/1vEolq9NdAlpiampKe/bs0YEDVz+tSiQSWlio/sTJcRwZhlGzrRHx+E3q69vR\nXMevI5HYXvM5V9x88w0NPX+t3Gb4letnNrnNo8AF0DU+9alf86agHDhwUH/2ZxS4CL5CoaDe3l7d\nc8893raBgQFNTk5W7Vcul2WappLJ5LptjVhcfE3z85c23/Fr9PRElUhsl21f1vJy5br7LC6+5t1+\n9dU36nr+enL96m+3ZZNbndsMClwAAHyyskTYSnE7NTWlvXv3qr+/v2rKgW3bMk3Tm2Nbq61ey8uV\nqvMUWqVW7vLymyf6VipuQ8/fif52aza5zaPABQDAB5Zlaf/+/d6KCK7rKplManh4WJKUy+U0Pj6u\nVCqlYrGoXC7nPbZWG4CNNVzg5vN5DQ0NVW1jsWoAAKqZpqkXX3xx3fZ0Ou2dhHbt/6u12gBsrO4C\nN5/Pq1wua3R0VOfPn1c8HvfaWKwaAAAA3aLudRiGhoY0PDxctfi0JM3Ozq67IHWtNgAAAMAPDS80\ndu2VoorF4roLUtdqAwAAAPzQ9Elm7VisWpJisfoWjK5XUBc9Dkqun9kb5UYi2tR7pZsXrAYAAPVr\nusBtx2LVktTbu6PtC1aT293Z1+auzIaJRqNNvVe6ccFqAABQv4YL3Gvn4LZjsWpJWli4pFjs5oYf\nt56gLnoclFw/s9fLXZk9U6lUNrW4eTcvWA0AAOrXcIF77RzcdixWLUlLS40tGF2voC16HLRcP7PX\ny3VdNfV83bhgNQAEzR//8eP68pf/V9W2d73rX+l3fufznekQtpS6C9xCoaCZmRlFIhGdPHlSg4OD\nymQyklisGuhmo6OjmpqaUiQSUX9/vx555BFvfU3WqQbgl3/4h5f0D//wUtW27//+93SoN9hq6i5w\nM5mMMpmMRkZG1rSxWDXQvXbu3Knz589LUtX61RLrVAMAwolL9QIh57rumsJWqr2G9WamEQHA0NAe\nvfTS2qVA3/e+Adl2uQM9wlZFgQuE3MLCgs6ePSvDMPT888/r4MGDMk2z5jrVFLgANmPbtm3ati25\nZvu1J6gDfqPABULu0KFDXsGaTCa9aQmtWqc6Go36skb16v8QY7HmnyNoa0mHcY3qbs0FED4UuEDI\nrT4aa5qm5ubmtLi42LJ1qhOJ7UomW79G9bZtPd7tZPLmlq2DHbS1pMOwRnW35wIIHwpcIMRmZ2d1\n+PBhvfDCC5JUVbzWWsO6EbZ9WZVK636VrKwbfOXK8qp+vbqptY2vlxuUtaTDtEZ1t+cCCB8KXITO\n66+/rtnZmYYfF4tFlEjcLNt+VUtLrlKplBKJtXPJgsQ0TR09etS7f+bMGQ0ODioej2+4hnW9KhV/\n1g1eveb20lLrniNoa0mHaY3qbs0FED4UuAgdy7qoj3wk03TOH/7hn2jv3p9oQY86xzAM9ff3a3x8\nXIZhyLIs1qkGAIQeBS4QcitrWF8P61QDAMKIAhehcfDgJ3T58uVNPz4SkebmZvQ3f/M3LewVWuEv\n//ILetvb3iZJ+shH/p3e8Y53drhHAIBuRoGL0Hjkkc829fhYLKr/8T8+T4HbhT7zmVHv9tTUUxS4\nAICaWAQQAAAAocIRXABd6Wd+5uf0wz88KEnK57+kZ5452+EeAWjWSy99Tab5tjXbn3vuOaXT7+1A\njxBWFLgAutKHP/yjuvPOD0uSvvWtb1LgAiHx+uuvr9m2ellAoBUocAEAgK/S6X4tLi5Wbfv2t7+p\n73znOx3qEcKOAhcAAPjqC184s2bb6Oh/1e///uc70BtsBZxkBgAAgFChwAUAAECoMEUBQKAsLMzr\n5ZdflnT1UsQ333xzh3sEAOg2HMEFECgPPHCvdu9+j3bvfo+mpv60090BAHQhClwAAACEClMUAHS9\nH/iB27Rnz09IkkolSxcu/F2HewQA6GYUuMA6ZmYuaMeOHU1lGIahO+64o0U92rr27TugffsOSJKe\neOKP9eCDn+xwjwAA3YwCF1jHo4/+dtMZ73vf+/XMM/93C3oDAADqxRxcAAAAhApHcIFVMpmMHnro\nV1SpNHdd9N/5nRMt6hEAAGgUBS6wyoc+9CHt3v1+LS1VmsqhwAUAoHOYogAAAIBQocAFAABAqDBF\nAQAAdNR3v/tdvfzyy1XTw7Zvv0mJRLKDvUKQUeACAICO+tjHPrZm23/4Dz+nz33u9zrQG4QBUxQA\nAAAQKhzBBQAAbZdO92vPnp9QNCpt2xbTlStLsm1HX/4yF8dB8yhwAQBA233iEz+rT3ziZxWLRdXX\nt0Pz85c0MzOrD36Qy5ujeUxRAAAAQKhQ4AIAACBUKHABAAAQKhS4AAAACBUKXAAAAIQKBS4AAABC\nhQIXAAAAoUKBCwAAgFChwAUAAECoUOACAAAgVChwAQAAECoUuAAAAAiVWKc7AAAAcK2XX/62nn/+\ny2u233nnBzvQGwQNBS4AAOg6zz57Ts8+e27N9ldesTvQGwQNUxQAAAAQKhzBBQAAXaGv73/Tgw/+\n5zXbJyf/RC+//O0O9AhB1ZYC17Is5fN5maapUqmk4eFhGYbRjqcGUANjE+hOW3Vs3nLLLfq1X/uN\nNduff/7LFLhoSFsK3Gw2q9OnT0uSHMdRNpvVxMREO54aQA2MTaA7MTaB5vg+B3d2dlaRSMS7bxiG\nisWiSqWS308NoAbGJtCdGJtA83wvcIvFonp7e6u2JZNJWZbl91MDqIGxCXQnxibQPN+nKNj22uU8\nDMOQ4zgN5cRiEcViravHe3qiVV/Jbf3fOkHrsz+5EV9e21Zo1diMRqNtHZvRaGTVvvX/XgjW+4ax\n2c7cbtOqsdnT096x6Wfu6iPanR7zfmaTW53bDN8L3EQioYWFhaptjuPUPVnedV0/uuVJJLaT62Ou\nn9ndnOv3+7YVmh2bkr/f53o/h1/8xaP6xV882vLcZgUt18/soOV2m6COTT9z/+ZvvuJLbrOC9l4P\nWm4zfP/zdWBgYM22crks0zT9fmoANTA2ge7E2ASa53uB29/fX/Wxim3bMk1TqVTK76cGUANjE+hO\njE2geRG3DZ+lzs3NaXp6WqlUSsViUQcPHmSgAl2AsQl0J8Ym0Jy2FLgAAABAu3TnKaQAAADAJlHg\nAgAAIFQocAEAABAqFLgAAAAIFQpcAAAAhIrvVzLbCkqlkizL8q4008r1Cv3KDlJukPraznxsjLHp\nb24QX1+/s1G/IL3Xg5Yb1PHTyuyuK3CD9AZyHEfZbFbFYlHJZNK7VvjKFWdyudymn8Ov7CDlBqmv\n7czvFMamv9lByg3i6+t3dicFaWxKwXqvBy03qOPHl2y3S9i27d57773u7bff7t51113uxz/+cfeu\nu+5yb7/9dnffvn2uZVldleu6rjs2Nubatn3dtnK57J44caLrsoOUG6S+tjO/3Rib7ckOUm4QX1+/\nszshiGPTdYP1Xg9ablDHjx/ZXXMEd2pqSrlcToZhrGmzbVunTp3SQw891DW5kpRKpa6bK0mJROK6\n1xPvdHaQcoPU13bmtxtjsz3ZQcoN4uvrd3YnBHFsSsF6rwctN6jjx4/srjnJLEhvoBWWZdVsL5VK\nXZcdpNwg9bWd+e3G2GxPdpByg/j6+p3dCUEcm1Kw3utByw3q+PEju2uO4AbpDbRiaGhI+/btUyQS\nUW9vryRpYWFB0tX5JLlcruuyg5QbpL62M7/dGJvtyQ5SbhBfX7+zOyGIY1MK1ns9aLlBHT9+ZEdc\n13U33aMWsixL2Wy25jeXTqe7Jne12dlZFYtF2bbt/XXb39/fVKbf2UHKDVJf25nfLozN9mYHKTeI\nr6/f2e0U5LEpBeu9HrTcoI6fVmZ3TYG7IkhvoBXtWnJmcXFRkhSPx5vOakefW9XfIPV1tbAtRcTY\nXB9jMzivr8TY7HTuiiC916Vg9Zex2YUFbpDeQH4umTE3N+f9hbzy1/Tc3JwkaXBwULlcblP996vP\nfvQ3SH1tR787jbF5FWMzmK+v3/3upCCNTSlY7/Wg9Zexucqm13RoMb+WJZmdnfVuX7x40f34xz/u\n7tq1y921a5d75MgR13GcTffZzyUz9u3b591+9NFH3ZmZGe+5nn766a5alsR1/elvkPq6GksR1Yex\nWS1I7/cgvr6uy9isl59j03WD9V533WD1l7H5pq4pcIP0Blpx5syZptpr2bVrl/dLZHp6ek375OTk\npnL96rMf/Q1SXxvpVzPvi05gbFZjbAbz9a2nX4zNq/w+CBCk93o9/emm/jI239Q1qyj4tSzJ7Oys\nFhcXFY/Hdeedd1bNH/roRz8q27Y3lSv5e6apu2rmiOM4a9qvt60efvXZj/4Gqa+rsRRRfRib1YL0\nfg/i6ysxNuvl59iUgvVel4LVX8bmm7qmwA3SG2iFn0tmDA8Pa3JyUq7ramFhQf39/UqlUrrjjjt0\n9OjRTU/0X6/PrutqcXFx0332o79+vb5+vbZ+97tTGJvVGJvBfH397ncnBHFsSsH73c7Y9K+/fva7\na04y82tZktHRUe3cudP7gRw6dGjNDySTyTTV93YuOTM7OyvTNNf9q72RnHb0uRX9DVJfr81jKaL1\nMTbXzwnK+z2Ir+9KFmNzfe0Ym1Kw3usrOUHpL2OziwrcFUF6A60olUprzu5b+Xinm7NX5124cEG7\nd+8ORO7KmZzXe226MVfyZxmydmNsti97dR5j099sxmZjz9PKgwB+jSHG5lpbcmw2PGsXnosXL7p3\n3XWXe9ttt7m7du1yp6amvLbJyUn3jjvu6LrsmZkZ96677vLOsJ2ZmXFvv/1297bbbnPvuOMOd25u\nrmtyHcdxLcta829sbMy1LMsdHR3dVF/9yl3h9xnI2Bhj099cP8eQn9mMze7g1xhibDI2V+u6I7jr\nKRQKLflIpJW52WxWe/fu1eDgoC5cuKCxsTHt2bNHBw4ckCTt2rVLL774YldlZ7NZ3XnnnZKkixcv\nam5uTplMRkNDQ7IsS1NTU/rc5z7XFbmjo6PK5/NKJpNVc8JW5p1FIhFvDb5uyF2xf/9+/fmf/7kk\n6b8Lp60AAApOSURBVMSJE9q7d6931OPMmTOamZnRQw89tOn8bsPYZGyuaMUY8jObsdkduX6OIcYm\nY9Oz6XLbB47jrPuvmWVJ/Mo9derUmm2Tk5NuPp93Xffqkhrdln3tMh6PPvpozfZO505PT69ZjmQl\n63qvUadzXdf/Zcg6gbHpfzZj0/9sxmbnc13XvzHE2LyKsXlV16yikM/nvcny7qq/DFbuRyKRTf1l\n7VfueoaHh1UoFFQoFFqW2crsZDKpF198Ubt27ZIkHTx4sKo9Eol0VW4mk5HjOHryySe1Z88exeNx\nL+va5+iGXMn/M5DbjbHZnmzGpv/ZjM3O5tbi1/hkbG7hsdl4ne2fWhV6M38Z+JU7PT3tnjp1yt21\na1fV/BHXdd1isejedtttXZc9PT3t3nbbbWuucPPoo4+6+/btq5qz1A251z7H9PR0S7L8zP31X/91\nd2xszD116pT76KOPeq/J7bff7o6NjV33r9Nux9j0P5ux6X82Y7Pzua7r7xhibK59jq06NruqwK11\npYpmfvH4leu6Vy+VuF7GxYsXuzb7enl+/HJvda5t275cbciv3NVWXw0oaBib7cu+Xt5WHpt+Z7su\nY7OduSv8GkOMzbW26tgMzElmAAAAQD2ine4AAAAA0EoUuAAAAAgVClwAAACECgUuAAD4/9u7f6A0\nnj4M4A+ZXwlKH7AGo+k8Arb8cZLKczRJCZikE8ckVWbAZOw8M7GNOKNdxNF0DsekDWTGEtHeIz3e\nmnrfIuO9AUFRAfF8PpV47H7PhUf37paTyFY4wSUiIiIiW+EEl4iIiIhshRNcIiIiIrKVezfB1TQN\nmUzGeqwoCtbX12+ltqZp8Pl8iEajiEQiCAQCSCaTODw8rGunqiq2t7dvVHt5eRmRSMSql81mb9Rf\nK9lsFj6fD36/H36/Hz6f79zjqakpAL0d+8vk8/m616YTY34mlUp15d/D2g2zyWw2w2zePmaT2Wym\n37P5X0f25A5bXV2F1+u9tfqPHj3Czs6O9VjXdaiqih8/fsDj8XSkxtzcHP78+YONjQ0MDg6iXC5j\na2urI303mp2dxezsrPVY0zQUCgUUCoVzz73tsT9jGAY+f/7cdB87YWlpCaqq4vv373A6nV2pYUe3\n/f5gNplNau623x/MJrPZjnt3BrdRMBhsOxC5XA6pVKqr+xOLxTAzMwNN0zrSnxAChUIBnz59wsOH\nD+F0OhEMBvHly5eO9H8TVxn7bspkMnj16lXX+ne5XHjx4gU+fPjQtRp2xGzeHmaTLsJs3h5ms333\nfoJ7VQ6Ho+s1hoaGYBhGR/pyuVxwOBw4Pj7uSH92YxgGSqUSpqenu1pnZmama0e69BezaS/Mpn0w\nm/ZyV7LZlxNcVVWhaRoSiQQURUEkEkG1WrW26bqOdDqNQCAAADBN03ru1NQUhBBWX4ZhQFVVBAIB\nzM/PnwtA45oRIQRSqRQURbHanH1P0zToum6t+blp7VbK5TJGRkbqvndycmLVSSQSOD09bbrP0WgU\nuVyurm0ymUQ8Hkc6nW66puWy9qqqIpvNWs85+znT6bTV5ujoqK2frbHff8f+qnWEEC3HPpVKIRKJ\nWNv+Ha9/lUolDA8PN9120Zg3ex/Ozc21rOlyueD3++/8H1Jmk9lkNvsTs8lsMpsNZB+anJyUqqpK\nIYQUQsh4PC4jkYi1bWxsTGqaJoUQUkopw+GwXFlZkVJKqeu6nJyctPoaGxuTmUxGSimlaZoyHA7L\ndDpdVyuXy9U9zmQyVt+6rltfr62tyVQqVbevN6m9vLwsVVWt6+/r16/S5/NJwzDq9klRFGs8wuGw\nzGazdfuwvr4upZRSCHHuZ5JSylwuJ1VVlT6fT/p8PpnP5y9sv7W1VVc/EonU1VcURR4dHUkppZyb\nm5OJREI2s7y8bL12jZqN/VXqtBr7fD5f97xisdi0/lmfmqY13beLxvzsfbiysiKFEG3VjMfjdX3c\nRcwms8ls9idmk9lkNuv15RlcAHj69CmcTiecTidWV1dhGIZ1NDo6Ooq3b9/C6XSiWCzCNE0sLCwA\nAKLRKNxuN6rVKorFIhwOBxYXFwH8PRoIBoMtaxaLRfz+/RuLi4vWouZoNNpygXMnalcqFQQCAevI\nt1KpNF0oPzExYY1HMBi0Lp3k83k4HA4kEgkAgNPpxNLSEpaXl+vaT09PY2dnB/v7+3j37h3m5+dx\ndHTUsn3jWqZgMFhX3+PxwOfzAQDGx8c7dmmo3ToXjT0AHBwcQNd1CCEufM2FEHC73U23tRrzM6Oj\no1hYWLDeH5fV9Hg8trjkxWwym8xmf2I2mU1m8//uxF0UXC4XpJTWizQxMWFtq1arODk5QTQaBQBI\nKeFwOCCEQLVavdJi7Os8/6a1h4aG2jr93njp5czBwcG5SwVerxdCCJyenp77JeN0OpFMJvHz50/s\n7e1BStlW+8b6/36Kc3Bw8NL9b1e7dS4a+1gshmq1Ck3TUK1WEYvFWn44oFarYWBgoK19afTv+7Cd\nmgMDA9YvErtgNpnNxjrMZn9gNpnNxjr3LZt3YoJrmiYcDkfTW2N4vV6Mj483vS9crVa70sB4vd4r\nP79Tta9rdHQUuq7Xfa9cLmNgYODSW2u43W54PJ5rt79NF4098Hf9VDKZRLVaRTweR6FQsEL9L7fb\nDdM0O7JP7da0E2azNWaT2bxNzGZrzOb9yGbfLlHY29uDEAKmaSKVSiEUCjU9sgsGg6jVanU3YNZ1\nHaenp9bp7pWVFQB/L2vk8/mWNc9O7Z/duNg0TeRyOStwXq8XlUoFQgiUSqWO1r6uWCwGh8Nh1TEM\nA5lMBm/evAEAHB4eQlEU5HI5GIYBIQTW1tZQqVTw/PnzS9v3q4vGvlQqWR8K8Hg8cLlcLfvp1KXJ\ndmoahtEX9y+8KWazPcwms9lrzGZ7mM37kc2+neCOjIxYnwp88OABVldXATS/3cjm5ibK5bK1HqdY\nLFrbNjY2kM/nEQgEkMvlEAqF6to29re5uYlarWZ9CrVSqVhrTUKhEEzTRDgctm74fJPa7brsFiu7\nu7s4Pj6GoihIJpN4+fKltTZoeHgYS0tL0HUdU1NTUBQFv379wu7urnWkeVH7dupfV2O/V61z0div\nra1BURT4/X48fvy45RHh0NBQ0zMGl+1Ls+2X1Tw8PLz2e6CfMJut97ERs8ls9hKz2XofGzGb9s+m\nQ0opr9Wyi1RVxbNnz6xbihB1i2EY175dy1UIIaAoCvb39/v6EtZlmE3qFWbzaphN6pW7ks2+PYNL\n1AterxehUOjceqpO+/btG2ZmZu70H1CiXmI2ifrTXclmX05we/FfT4jOLC4uWmupusE0TWSzWbx/\n/75rNXqF2aReYjbbx2xSL92FbPblEgWiXtve3sbBwQE+fvzY8b4TiQRev36NJ0+edLxvIrtjNon6\nU79nkxNcIiIiIrKVvlyiQERERER0XZzgEhEREZGtcIJLRERERLbCCS4RERER2QonuERERERkK5zg\nEhEREZGtcIJLRERERLbCCS4RERER2cr/AB9vmcH4Jwv+AAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x11c63a190>"
+       "<matplotlib.figure.Figure at 0x11d6be2d0>"
       ]
      },
      "metadata": {},
@@ -781,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -792,13 +792,105 @@
        "2109"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "len(ops.obsHistIDsPredictedToTakeTooLong)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run 3p4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>obsHistID</th>\n",
+       "      <th>expMJD</th>\n",
+       "      <th>predictedPhoSimTimes</th>\n",
+       "      <th>filter</th>\n",
+       "      <th>propID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>228838</td>\n",
+       "      <td>59895.256522</td>\n",
+       "      <td>122.754463</td>\n",
+       "      <td>i</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>54</th>\n",
+       "      <td>228869</td>\n",
+       "      <td>59895.270791</td>\n",
+       "      <td>124.551268</td>\n",
+       "      <td>i</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>62</th>\n",
+       "      <td>250374</td>\n",
+       "      <td>59926.155500</td>\n",
+       "      <td>133.308348</td>\n",
+       "      <td>r</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>63</th>\n",
+       "      <td>250407</td>\n",
+       "      <td>59926.170531</td>\n",
+       "      <td>124.940012</td>\n",
+       "      <td>r</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>69</th>\n",
+       "      <td>269090</td>\n",
+       "      <td>59954.135576</td>\n",
+       "      <td>153.976707</td>\n",
+       "      <td>i</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    obsHistID        expMJD  predictedPhoSimTimes filter  propID\n",
+       "53     228838  59895.256522            122.754463      i      54\n",
+       "54     228869  59895.270791            124.551268      i      54\n",
+       "62     250374  59926.155500            133.308348      r      54\n",
+       "63     250407  59926.170531            124.940012      r      54\n",
+       "69     269090  59954.135576            153.976707      i      54"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ops.Twinkles_3p4[0].head()"
    ]
   },
   {

--- a/python/desc/twinkles/obsHistIDOrdering.py
+++ b/python/desc/twinkles/obsHistIDOrdering.py
@@ -166,7 +166,7 @@ class OpSimOrdering(object):
 
         missing = self.uniqueOpSimRecords.query('obsHistID not in @filteredObsHistID')
         if len(missing) > 0:
-            return missing[['obsHistID', 'predictedPhoSimTimes', 'filter', 'propID']]
+            return missing[['obsHistID', 'expMJD', 'predictedPhoSimTimes', 'filter', 'propID']]
         else:
             return None
 
@@ -226,6 +226,13 @@ class OpSimOrdering(object):
 
     @property
     def Twinkles_3p3(self):
+        """
+        dataFrame of visit obsHistID for Run 3p3. These are DDF visits
+        that have `predictedPhoSimRunTime` smaller than `maxtime`, and
+        were not covered in either the set of unique visits covered in
+        Run 3.1 or the visits in a particular year covered as part of
+        3.2 
+        """
         obs_1 = self.Twinkles_3p1.obsHistID.values.tolist()
         obs_1b = self.Twinkles_3p1b.obsHistID.values.tolist()
         obs_2 = self.Twinkles_3p2.obsHistID.values.tolist()
@@ -233,7 +240,21 @@ class OpSimOrdering(object):
         query = 'obsHistID not in @obs'
         return self.filteredOpSim.query(query).sort_values(by='expMJD',
                                                            inplace=False)
-        
+    @property
+    def Twinkles_3p4(self):
+        """
+        tuple of dataFrames for wfd and ddf visits for visits left out
+        of Run 3p1,2,3 due to high predicted phosim times, orderded by
+        predicted phosim run times.
+        """
+        leftovers = self.obsHistIDsPredictedToTakeTooLong
+        wfdvisits = leftovers.query('propID == 54')
+        wfdvisits.sort_values(by='expMJD', inplace=True)
+        ddfvisits = leftovers.query('propID == 56')
+        ddfvisits.sort_values(by='expMJD', inplace=True)
+        return wfdvisits, ddfvisits
+
+
     @staticmethod
     def fullOpSimDF(opsimdbpath,
                     query="SELECT * FROM Summary WHERE FieldID == 1427 ORDER BY PROPID"):


### PR DESCRIPTION
out of Twinkles 3p1-3 due to estimates of PhoSim run times being too
long

- Added code to define the visits for Twinkles 3p4 split into two tuple
  elements for WFD, and DDF
	modified:   python/desc/twinkles/obsHistIDOrdering.py
- Modified the script to generate these visits
	modified:   bin/get_twinkles_visits.py
- Modified example notebook to demonstrate this
	modified:   examples/notebooks/Example_OpSimOrdering.ipynb
Fixes #416